### PR TITLE
Fix routes hallucination: stop misrouting reactive follow-ups as place names

### DIFF
--- a/capabilities/routes/tools.py
+++ b/capabilities/routes/tools.py
@@ -204,8 +204,9 @@ def is_bare_place_fragment(text: str) -> bool:
     if not re.fullmatch(r"[a-z0-9 ,'\-\.]+", lowered):
         return False
     if re.search(
-        r"\b(please|me|my|the|what|when|how|which|route|bus|remind|expense|"
-        r"email|grocery|recipe|bill|to|from|at|near|next|arriv)\b",
+        r"\b(please|me|my|the|what|when|how|which|route|bus|buses|remind|expense|"
+        r"email|grocery|recipe|bill|to|from|at|near|next|arriv|"
+        r"no|not|yes|yeah|nah|other|others|different|instead|again|want|wanna|dont)\b",
         lowered,
     ):
         return False

--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -349,8 +349,9 @@ def deterministic_plan(
     ).get("ordering") == ["routes"]
     if active_routes_thread and re.fullmatch(r"[a-z0-9 ,'\-\.]{2,40}", text):
         if not re.search(
-            r"\b(please|me|my|the|what|when|how|which|route|bus|remind|expense|"
-            r"email|grocery|recipe|bill|to|from|at|near|next|arriv)\b",
+            r"\b(please|me|my|the|what|when|how|which|route|bus|buses|remind|expense|"
+            r"email|grocery|recipe|bill|to|from|at|near|next|arriv|"
+            r"no|not|yes|yeah|nah|other|others|different|instead|again|want|wanna|dont)\b",
             text,
         ):
             return Decision(
@@ -510,6 +511,11 @@ def llm_plan_prompt(
         "they expect you to have seen (e.g. \"did u see the one from DBS today?\", \"there's an email from "
         "payroll\"), even without the literal word 'email' — never answer from memory or assumption about "
         "inbox contents.\n"
+        "5. If an active thread domain is given (e.g. \"Current thread domain: routes\") and the message is "
+        "a short reactive follow-up about the same thing — a correction, a request for alternatives, "
+        "confirming/rejecting an option (e.g. \"no I want other buses\", \"what about walking instead\") — "
+        "keep it on that same domain rather than dropping to 'general'. Never invent route steps, bus "
+        "numbers, or timings from memory; only report what a route/transit tool call actually returned.\n"
         "Reply ONLY with JSON:\n"
         '{"capabilities":[{"id":"...","reason":"...","confidence":0.0-1.0}], '
         '"ordering":["..."],"insufficient_capability":null|{"missing_capabilities":["..."],"reasons":["..."]}'

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -94,6 +94,20 @@ def test_bare_place_fragment_reuses_routes_thread():
     assert deterministic_plan("who is Albert Einstein", _state("who is Albert Einstein"), None).recipe is None
 
 
+def test_bare_place_fragment_excludes_conversational_followups():
+    """Regression (#15): "no I want other buses" is a reactive follow-up, not a
+    place name — it used to fullmatch the bare-fragment shape with no excluded
+    word hit ("buses" doesn't word-boundary-match "bus"), so it got silently
+    treated as a destination fragment instead of being planned/routed properly."""
+    state = {
+        "active_domain": "routes",
+        "last_decision": {"ordering": ["routes"], "capabilities": [{"id": "routes"}]},
+        "messages": [HumanMessage(content="route from Tampines to Suntec")],
+    }
+    decision = deterministic_plan("no i want other buses", state, None)
+    assert decision.source != "fragment-reuse"
+
+
 @pytest.mark.asyncio
 async def test_plugin_state_update_merged_by_plan_router(monkeypatch):
     from unittest.mock import AsyncMock, patch

--- a/tests/test_routes_live.py
+++ b/tests/test_routes_live.py
@@ -38,6 +38,12 @@ def test_bus_arrival_vs_directions_classification():
     assert is_bare_place_fragment("suntec city") is True
     assert is_bare_place_fragment("to suntec") is False
     assert is_bare_place_fragment("what bus should i take") is False
+    # Regression (#15): a conversational follow-up rejecting/alternating the
+    # current route ("no I want other buses") is not a place name, but used to
+    # slip past the exclusion list (no word-boundary "bus" match on "buses",
+    # and none of "no"/"want"/"other" were excluded) and get treated as one.
+    assert is_bare_place_fragment("no i want other buses") is False
+    assert is_bare_place_fragment("other one") is False
 
 
 def test_lta_format_arrivals_shows_bus_numbers():


### PR DESCRIPTION
## Summary

Two related fixes for #15 (hallucinated transit route without tool invocation):

1. **`is_bare_place_fragment()` exclusion list was too narrow.** A reactive follow-up like *"no I want other buses"* fullmatches the bare-fragment shape (`[a-z0-9 ,'\-\.]{2,40}`) and hits none of the excluded words — `"buses"` doesn't word-boundary-match `"bus"`, and words like "no"/"other"/"want" weren't excluded at all. So it silently got treated as a literal place-name fragment reusing the active route thread, in both `is_bare_place_fragment` (`capabilities/routes/tools.py`) and its duplicated inline check in `deterministic_plan` (`orchestrator/planner.py`). Extended both exclusion lists with common negation/continuation words and the plural "buses".

2. **The LLM planner had no "stay in the active domain" rule outside whiteboard.** `llm_plan_prompt` explicitly told the planner to keep follow-ups on `whiteboard` when that thread is active, but nothing equivalent existed for any other domain — so a routes follow-up like this could plausibly fall through to `general`, which (per the hallucination guardrail already shipped for #10/#4) is exactly how routes end up inventing transit details instead of calling the real tool. Added a general rule covering this for any active domain, plus an explicit reminder never to invent route steps/bus numbers/timings without a real tool call.

## Testing

- Regression tests for both fixes (`tests/test_routes_live.py`, `tests/test_planner.py`) — verified they fail against the pre-fix code via `git stash` and pass against the fix.
- Full suite: 200 passed. Same 8 pre-existing failures as `main` (sandboxed code-exec tests and an LLM-provider-gating test unrelated to this change).

Closes #15.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_