### PR TITLE
Fix: one email provider's failure was crashing the whole search (Outlook)

### DIFF
--- a/capabilities/email/tools.py
+++ b/capabilities/email/tools.py
@@ -192,24 +192,33 @@ async def search_email_messages(
     else:
         providers_to_query = await get_active_providers_for_user(user_id)
 
-    tasks = []
-    for p_name in providers_to_query:
-        if p_name in PROVIDER_REGISTRY:
-            tasks.append(
-                PROVIDER_REGISTRY[p_name].search_messages(
-                    user_id=user_id,
-                    tracked_banks=tracked_banks,
-                    custom_query=custom_query,
-                    latest=latest,
-                )
-            )
+    queried_providers = [p_name for p_name in providers_to_query if p_name in PROVIDER_REGISTRY]
+    tasks = [
+        PROVIDER_REGISTRY[p_name].search_messages(
+            user_id=user_id,
+            tracked_banks=tracked_banks,
+            custom_query=custom_query,
+            latest=latest,
+        )
+        for p_name in queried_providers
+    ]
 
     if not tasks:
         return []
 
-    results = await asyncio.gather(*tasks)
+    # return_exceptions=True: every provider here (IMAP, mock) already swallows
+    # its own errors and returns [] on failure, except the real Gmail/Outlook
+    # OAuth paths, which can raise on a network blip or a rejected token
+    # exchange. Without this, asyncio.gather propagates that single provider's
+    # exception and discards results from every OTHER provider that already
+    # succeeded — one flaky mailbox taking down the whole search and crashing
+    # the webhook turn instead of degrading gracefully.
+    results = await asyncio.gather(*tasks, return_exceptions=True)
     merged_messages = []
-    for res in results:
+    for p_name, res in zip(queried_providers, results):
+        if isinstance(res, BaseException):
+            print(f"[EMAIL] {p_name} search failed, skipping: {type(res).__name__}: {res}")
+            continue
         merged_messages.extend(res)
     return _sort_messages_newest_first(merged_messages)
 

--- a/tests/test_email_and_expenses.py
+++ b/tests/test_email_and_expenses.py
@@ -109,6 +109,36 @@ async def test_search_email_messages_multi_provider():
     unified_results = await search_email_messages.ainvoke({"user_id": 3002})
     assert len(unified_results) >= 1
 
+
+@pytest.mark.asyncio
+async def test_search_email_messages_survives_one_provider_failing(monkeypatch):
+    """Regression: one provider raising (e.g. Outlook's OAuth/Graph call hitting a
+    network blip or a rejected token) used to take down the WHOLE search via
+    asyncio.gather's default fail-fast behavior, discarding results from every
+    OTHER provider that already succeeded — the webhook crashed with the generic
+    "something glitched" fallback instead of degrading gracefully."""
+    import capabilities.email.providers as providers_mod
+    import capabilities.email.tools as tools_mod
+
+    async def fake_gmail(*a, **k):
+        return [{"id": "g1", "provider": "gmail", "subject": "ok", "sender": "a@b.com", "snippet": "", "date": ""}]
+
+    async def fake_outlook(*a, **k):
+        raise RuntimeError("simulated Graph API failure")
+
+    monkeypatch.setattr(providers_mod.PROVIDER_REGISTRY["gmail"], "search_messages", fake_gmail)
+    monkeypatch.setattr(providers_mod.PROVIDER_REGISTRY["outlook"], "search_messages", fake_outlook)
+
+    async def fake_active_providers(user_id):
+        return ["gmail", "outlook"]
+
+    monkeypatch.setattr(tools_mod, "get_active_providers_for_user", fake_active_providers)
+
+    result = await tools_mod.search_email_messages.ainvoke({"user_id": 1})
+    assert len(result) == 1
+    assert result[0]["provider"] == "gmail"
+
+
 @pytest.mark.asyncio
 async def test_apply_email_processed_tag():
     """Outlook processed-tag hits Microsoft Graph when an OAuth token is stored."""


### PR DESCRIPTION
## Summary

Reported directly: "check outlook email for transactions" fails terribly instead of degrading gracefully.

Root cause: `search_email_messages()` (`capabilities/email/tools.py`) gathered per-provider search coroutines with plain `asyncio.gather()`, which fails fast — if any provider's search task raises, the whole call raises and discards results from every *other* provider that already succeeded. `EmailPlugin.execute()` has no try/except around this call, so the exception propagates all the way to the top-level webhook handler and surfaces as the generic "something glitched" crash reply.

This hits the real OAuth/Graph-API-backed providers specifically: unlike the IMAP fallback (`_fetch_outlook_imap`), which already wraps its own errors and returns `[]` per its own docstring ("Returns [] when the mailbox is unreachable"), neither `_search_real_gmail` nor `_search_real_outlook` catches its own httpx/token-exchange errors — a network blip or a rejected token exchange while checking Outlook for transactions takes the entire search down instead of degrading.

## Fix

`asyncio.gather(*tasks, return_exceptions=True)`, logging and skipping whichever provider raised instead of losing every provider's results to one flaky mailbox.

## Testing

- Added a regression test reproducing the exact failure (one provider raises while another succeeds) — verified via `git stash` that it fails against the pre-fix code (crashes with the same traceback shape reported) and passes against the fix.
- Full suite: 201 passed. Same 8 pre-existing failures as `main` (sandboxed code-exec tests and an LLM-provider-gating test, unrelated to this change).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_