### PR TITLE
Fix: email search ignores an explicitly named provider (Outlook)

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -144,6 +144,21 @@ class EmailPlugin:
         requested_outlook = any(word in lowered_text for word in ("outlook", "hotmail", "microsoft mail", "office 365"))
         requested_gmail = any(word in lowered_text for word in ("gmail", "google mail"))
 
+        # When the user names exactly one provider ("check outlook for...",
+        # "see my gmail"), scope the search to that mailbox instead of merging
+        # every connected provider. Without this, a user with both Gmail and
+        # Outlook connected who explicitly asks about Outlook silently gets
+        # Gmail's (irrelevant) results back with no indication Outlook was
+        # ever queried — the exact "outlook fails terribly" report: the
+        # assistant summarizes generic Gmail promos and finds no transactions,
+        # with nothing in the reply signaling it never actually looked at
+        # Outlook.
+        requested_provider_scope: Optional[str] = None
+        if requested_outlook and not requested_gmail:
+            requested_provider_scope = "outlook"
+        elif requested_gmail and not requested_outlook:
+            requested_provider_scope = "gmail"
+
         # One-time mailbox authorization: the bot can't read email until the user consents.
         # Offer whichever providers are still missing (Gmail and/or Outlook).
         gmail_token = await get_user_gmail_token(user_id)
@@ -187,14 +202,18 @@ class EmailPlugin:
         # request without an explicit financial intent; the keyword sweep runs
         # only for receipt/bill/expense/bank asks.
         if is_latest_email_request(last_text) or not is_financial_email_request(last_text):
-            latest_results = await search_email_messages.ainvoke({"user_id": user_id, "latest": True})
+            latest_results = await search_email_messages.ainvoke(
+                {"user_id": user_id, "latest": True, "provider": requested_provider_scope}
+            )
             reply = AIMessage(content=await self._summarize_email_results(latest_results, latest=True))
             return PluginOutput(
                 message=reply,
                 state_update={"active_domain": self.name},
             )
 
-        results = await search_email_messages.ainvoke({"user_id": user_id})
+        results = await search_email_messages.ainvoke(
+            {"user_id": user_id, "provider": requested_provider_scope}
+        )
         if results:
             for msg in results:
                 sender = msg.get("sender", "")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -208,6 +208,93 @@ async def test_email_plugin_generic_inbox_ask_uses_latest_mode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_email_plugin_scopes_financial_sweep_to_named_provider(monkeypatch):
+    """Regression: "look for transactions from my outlook ... log them as expenses"
+    used to search ALL connected providers merged together, silently ignoring the
+    explicit 'outlook' instruction — a user with Gmail also connected got Gmail's
+    unrelated inbox summarized back with no indication Outlook was ever queried,
+    and nothing got logged despite an explicit expense-logging request."""
+    from unittest.mock import AsyncMock
+    import orchestrator.router as router_module
+    import capabilities.email.tools as email_tools
+
+    captured: dict = {}
+
+    async def fake_search(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(router_module, "get_user_gmail_token", AsyncMock(return_value="mock_gmail_token"))
+    monkeypatch.setattr(router_module, "get_user_outlook_token", AsyncMock(return_value="mock_outlook_token"))
+    monkeypatch.setattr(email_tools.search_email_messages, "coroutine", fake_search)
+
+    await EmailPlugin().execute({
+        "messages": [HumanMessage(
+            content="Can you look for all transactions from my outlook for the past two days and log them as expenses"
+        )],
+        "user_id": 4001,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+    assert captured.get("provider") == "outlook"
+
+
+@pytest.mark.asyncio
+async def test_email_plugin_scopes_latest_mode_to_named_gmail(monkeypatch):
+    """Symmetric case on the latest-mode call site: naming Gmail explicitly
+    must scope the search to Gmail, not merge in Outlook too."""
+    from unittest.mock import AsyncMock
+    import orchestrator.router as router_module
+    import capabilities.email.tools as email_tools
+
+    captured: dict = {}
+
+    async def fake_search(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(router_module, "get_user_gmail_token", AsyncMock(return_value="mock_gmail_token"))
+    monkeypatch.setattr(router_module, "get_user_outlook_token", AsyncMock(return_value="mock_outlook_token"))
+    monkeypatch.setattr(email_tools.search_email_messages, "coroutine", fake_search)
+
+    await EmailPlugin().execute({
+        "messages": [HumanMessage(content="what's new in my gmail")],
+        "user_id": 4001,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+    assert captured.get("provider") == "gmail"
+    assert captured.get("latest") is True
+
+
+@pytest.mark.asyncio
+async def test_email_plugin_no_provider_scope_when_unnamed(monkeypatch):
+    """When the user doesn't name a specific provider, keep searching every
+    connected mailbox (existing behavior must not regress)."""
+    from unittest.mock import AsyncMock
+    import orchestrator.router as router_module
+    import capabilities.email.tools as email_tools
+
+    captured: dict = {}
+
+    async def fake_search(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(router_module, "get_user_gmail_token", AsyncMock(return_value="mock_gmail_token"))
+    monkeypatch.setattr(router_module, "get_user_outlook_token", AsyncMock(return_value="mock_outlook_token"))
+    monkeypatch.setattr(email_tools.search_email_messages, "coroutine", fake_search)
+
+    await EmailPlugin().execute({
+        "messages": [HumanMessage(content="any new transactions I should know about?")],
+        "user_id": 4001,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+    assert captured.get("provider") is None
+
+
+@pytest.mark.asyncio
 async def test_email_plugin_financial_ask_keeps_sweep_mode(monkeypatch):
     """Explicit financial intents ('receipts') must stay on the keyword sweep (latest=False)."""
     from unittest.mock import AsyncMock


### PR DESCRIPTION
## Summary

Root-caused from real production logs (Railway), not just code reading — this is the actual bug behind "outlook integration fails terribly."

User: *"Can you look for all transactions from my outlook for the past two days and log them as expenses"* → assistant replies with a generic summary of LinkedIn/promo emails, logs nothing. Follow-up `/expenses` confirms: *"No expenses logged yet."*

No crash, no exception — the logic silently ignores the word "outlook."

`EmailPlugin.execute()` already computes `requested_outlook`/`requested_gmail` from the message text, but only used them to pick which OAuth connect link to offer when a mailbox isn't linked yet. Once both mailboxes are connected, neither call site to `search_email_messages()` passed a `provider` — so the search always merged every connected provider via `get_active_providers_for_user()`. A user with both Gmail and Outlook connected who explicitly names Outlook silently gets Gmail's irrelevant results back, with nothing in the reply signaling Outlook was never actually queried.

## Fix

When exactly one provider is named in the message, pass it through as `search_email_messages(provider=...)` on both the latest-mode and financial-sweep call sites. Left unscoped (search everything — existing behavior) when neither or both are named.

## Testing

- Three regression tests: explicit "outlook" + financial intent scopes to outlook (matches the real repro above), explicit "gmail" scopes the latest-mode call site too, and an unnamed request still searches every connected provider (no regression). Verified the first two fail against the pre-fix code and pass against the fix.
- Full suite: 204 passed. Same 8 pre-existing failures as `main` (sandboxed code-exec tests and an LLM-provider-gating test, unrelated to this change).

Related to (but distinct from) #18, which fixed a real crash path in the same function — this fixes a silent logic bug that produces no exception at all, confirmed against actual production conversation logs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_