### PR TITLE
Shorten conversation audit cadence to every 4 messages

### DIFF
--- a/core/audit.py
+++ b/core/audit.py
@@ -276,7 +276,7 @@ async def _judge_conversation_with_gemini(transcript: list[dict]) -> dict:
     return json.loads(raw)
 
 
-def should_audit_conversation(user_message_count: int, every_n: int = 10) -> bool:
+def should_audit_conversation(user_message_count: int, every_n: int = 4) -> bool:
     """Audit a conversation when the user message count hits the cadence."""
     return user_message_count > 0 and user_message_count % every_n == 0
 

--- a/tests/test_conversation_audit.py
+++ b/tests/test_conversation_audit.py
@@ -10,9 +10,12 @@ from core.models import ConversationAuditLog
 
 
 def test_conversation_audit_cadence():
-    assert should_audit_conversation(10) is True
-    assert should_audit_conversation(20) is True
-    assert should_audit_conversation(4) is False
+    """Default cadence is every 4 user messages (#16: shortened from 10 so a
+    frustrated user's turns get caught sooner instead of waiting out a long
+    fixed interval)."""
+    assert should_audit_conversation(4) is True
+    assert should_audit_conversation(8) is True
+    assert should_audit_conversation(3) is False
     assert should_audit_conversation(0) is False
     assert should_audit_conversation(6, every_n=3) is True
     assert should_audit_conversation(4, every_n=3) is False


### PR DESCRIPTION
## Summary

#16 asked for the automated audit to also trigger when the user isn't getting the reply they want, not just on a fixed cadence. Two options were on the table (shorten the cadence, or add a sentiment/frustration signal); the owner picked the simpler one directly on the issue: *"Shorten the audit cadence to 4."*

`should_audit_conversation()`'s default `every_n` drops from 10 to 4, so a frustrated user's turns get caught by the LLM-judge audit roughly 2.5x sooner instead of waiting out a longer fixed interval.

## Testing

- Updated the existing cadence test to the new default (was asserting the old every-10 behavior).
- Full suite: 204 passed. Same 8 pre-existing failures as `main`, unrelated to this change.

Closes #16.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_