### PR TITLE
Fix: retrospective flight queries wrongly flagged as a capability gap

### DIFF
--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -195,12 +195,25 @@ def _has_word(text: str, words: list[str]) -> bool:
     return any(re.search(rf"\b{re.escape(word)}\b", text) for word in words)
 
 
+_RETROSPECTIVE_QUERY_MARKERS = (
+    "did i", "have i", "did we", "have we", "when did i", "when did we",
+    "check my email", "check my outlook", "check my gmail", "check my inbox",
+)
+
+
 def missing_policy(text: str) -> list[str]:
     """Missing-capability detection. Deliberately narrower than the legacy guardrail."""
     missing: list[str] = []
     if _has(text, ["calendar", "appointment", "meeting", "invite"]):
         missing.append("calendar")
-    if _has(text, ["book a flight", "flight to ", "flight from ", "book a hotel"]):
+    # "book a flight"/"book a hotel" are meant to catch forward-looking booking
+    # requests. A retrospective status check ("did I book a flight on 24 Jul?
+    # Check my outlook") contains the same substring but is really an email
+    # lookup — flagging it as a missing flight_booking capability blocks (or
+    # muddies) the perfectly-supported email search instead.
+    if not _has(text, _RETROSPECTIVE_QUERY_MARKERS) and _has(
+        text, ["book a flight", "flight to ", "flight from ", "book a hotel"]
+    ):
         missing.append("flight_booking")
     if _has(text, ["transfer", "send money", "wire "]):
         missing.append("bank_transfer")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -4,7 +4,7 @@ from langchain_core.messages import AIMessage
 
 from capabilities.registry import load_registry
 from capabilities.retrieval import BM25Index
-from orchestrator.planner import decision_from_dict, deterministic_plan, plan_with_llm
+from orchestrator.planner import decision_from_dict, deterministic_plan, missing_policy, plan_with_llm
 from orchestrator.graph import get_assistant_graph
 
 
@@ -262,3 +262,23 @@ async def test_llm_planner_used_when_key_present(monkeypatch):
     assert decision is not None
     assert decision.source == "llm"
     assert decision.capability_ids == ["expenses"]
+
+
+def test_missing_policy_excludes_retrospective_flight_queries():
+    """Regression (#21): "did I book a flight on 24 Jul? Check my outlook" is an
+    email lookup, not a request to book a NEW flight — but missing_policy's
+    "book a flight" substring check fired on it anyway, entangling a perfectly
+    supported email search with a flight_booking capability-gap refusal."""
+    retrospective = "did i book a flight on 24 jul? check my outlook"
+    assert "flight_booking" not in missing_policy(retrospective)
+
+    # A genuine forward-looking booking request must still be flagged.
+    forward_looking = "please book a flight to tokyo next friday"
+    assert "flight_booking" in missing_policy(forward_looking)
+
+
+def test_deterministic_plan_routes_retrospective_flight_query_to_email():
+    text = "did i book a flight on 24 jul? check my outlook"
+    decision = deterministic_plan(text, _state(text), None)
+    assert "email" in decision.capability_ids
+    assert decision.insufficient is None


### PR DESCRIPTION
## Summary

*"Did I book a flight on 24 Jul? Check my outlook"* is an email lookup — the user wants to know if a confirmation email arrived, not to book a new flight. `missing_policy()` (`orchestrator/planner.py`) checks for the literal substring `"book a flight"`, which matches regardless of tense, so it appends `flight_booking` to `Decision.insufficient` even though `_candidate_selections` correctly also adds `email` as a candidate (the message contains "outlook"). That produces a decision with both `capabilities=[email]` and a `flight_booking` insufficiency message attached — verified this exact shape with a reproduction — which can surface as a flat "I can't do that yet: no capability exists for #flight_booking" refusal for a request the email capability already fully supports.

## Fix

`missing_policy()` now skips the flight_booking check when the message carries a retrospective/status-check marker ("did I", "have I", "check my outlook", etc.). A genuine forward-looking request ("book a flight to Tokyo") is unaffected.

## Testing

- Regression tests: `missing_policy()` directly, and an end-to-end `deterministic_plan()` check that the retrospective query routes cleanly to `email` with no insufficiency attached. Verified both fail against the pre-fix code and pass against the fix.
- Full suite: 206 passed. Same 8 pre-existing failures as `main`, unrelated to this change.

Related to #21 — this fixes the routing bug specifically; the broader "search/book flights" capability itself is still a genuine wishlist item and stays open there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_