### PR TITLE
Fix: stop assuming photos are receipts; answer email questions directly

### DIFF
--- a/capabilities/expenses/tools.py
+++ b/capabilities/expenses/tools.py
@@ -656,30 +656,45 @@ async def extract_expense_from_photo(
     caption: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Extract structured expense fields from a receipt photo using Gemini vision.
-    Returns amount, currency, merchant, category, date_iso, confidence, needs_clarification.
+    Classify a photo and, only if it's actually a receipt, extract structured
+    expense fields from it using Gemini vision.
+
+    Returns amount, currency, merchant, category, date_iso, confidence,
+    needs_clarification when it's a receipt. When it isn't, amount is None
+    and `description` carries a one-line description of what the image
+    actually shows (a points/rewards balance, a screenshot, a random photo,
+    etc.) so the caller can respond honestly instead of assuming every photo
+    is a failed receipt scan.
     """
     if (
         not settings.active_gemini_api_key
         or settings.active_gemini_api_key == "test_google_key"
     ):
-        return {"amount": None}
+        return {"amount": None, "description": None}
 
     llm = get_multimodal_llm(temperature=0.1)
     prompt_text = (
         caption
-        or "Extract the expense shown in this receipt photo."
+        or "Look at this photo. If it's a receipt, extract the expense; otherwise describe what it shows."
     )
     ai_message = await llm.ainvoke(
         [
             SystemMessage(
                 content=(
-                    "You extract expenses from receipt photos. Reply with ONLY a JSON object: "
-                    '{"amount": number, "currency": string (3-letter code, default SGD), '
+                    "You look at a photo and first decide whether it is a purchase "
+                    "receipt/invoice with a legible total, or something else entirely "
+                    "(e.g. a rewards/points/miles balance, a screenshot, an unrelated "
+                    "photo). Do not assume it is a receipt just because you were asked "
+                    "to look at it. Reply with ONLY a JSON object: "
+                    '{"amount": number|null, "currency": string (3-letter code, default SGD), '
                     '"merchant": string, "category": string, "date_iso": string (ISO 8601 with time and timezone if mentioned, e.g. 2026-08-16T14:32:00, or YYYY-MM-DD), '
-                    '"confidence": number 0-1, "needs_clarification": boolean}. '
-                    "Read the TOTAL from the receipt. If there is no legible receipt or amount, "
-                    'return {"amount": null}.'
+                    '"confidence": number 0-1, "needs_clarification": boolean, '
+                    '"description": string}. '
+                    "If it IS a legible receipt, read the TOTAL and fill amount/currency/merchant/etc. "
+                    "If it is NOT a receipt (or the total isn't legible), set amount to null and "
+                    "put a short, specific description of what the photo actually shows in "
+                    "'description' (e.g. \"a DBS rewards points balance screenshot\") — "
+                    "never leave description generic like \"an image\"."
                 )
             ),
             HumanMessage(
@@ -695,7 +710,7 @@ async def extract_expense_from_photo(
     try:
         parsed = json.loads(raw)
         if not parsed.get("amount"):
-            return {"amount": None}
+            return {"amount": None, "description": parsed.get("description") or None}
         return {
             "amount": float(parsed["amount"]),
             "currency": parsed.get("currency") or "SGD",
@@ -707,7 +722,7 @@ async def extract_expense_from_photo(
         }
     except Exception as exc:  # noqa: BLE001
         print(f"[EXPENSES] photo extraction parse failed: {exc}")
-        return {"amount": None}
+        return {"amount": None, "description": None}
 
 
 async def extract_itemized_receipt_from_image(

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -205,7 +205,9 @@ class EmailPlugin:
             latest_results = await search_email_messages.ainvoke(
                 {"user_id": user_id, "latest": True, "provider": requested_provider_scope}
             )
-            reply = AIMessage(content=await self._summarize_email_results(latest_results, latest=True))
+            reply = AIMessage(
+                content=await self._summarize_email_results(latest_results, latest=True, user_question=last_text)
+            )
             return PluginOutput(
                 message=reply,
                 state_update={"active_domain": self.name},
@@ -248,12 +250,15 @@ class EmailPlugin:
                 state_update={"active_domain": self.name},
             )
 
-        reply = AIMessage(content=await self._summarize_email_results(results))
+        reply = AIMessage(content=await self._summarize_email_results(results, user_question=last_text))
         return PluginOutput(message=reply, state_update={"active_domain": self.name})
 
     @staticmethod
-    async def _summarize_email_results(results: List[Dict[str, Any]], latest: bool = False) -> str:
-        """Summarize fetched emails with the agent LLM, or fall back to a plain list."""
+    async def _summarize_email_results(
+        results: List[Dict[str, Any]], latest: bool = False, user_question: str = ""
+    ) -> str:
+        """Answer the user's actual question from fetched emails, or fall back to
+        a general summary for generic asks ("what's new", "check my latest email")."""
         if not results:
             if latest:
                 return "📬 I couldn't find any emails in your mailbox right now."
@@ -274,15 +279,30 @@ class EmailPlugin:
         try:
             llm = get_agent_llm(complexity=ThinkingLevel.LOW, temperature=0.4)
             emails_text = json.dumps(results[:8], indent=1, default=str)
+            question = (user_question or "").strip()
+            if question:
+                instruction = (
+                    "The user asked a specific question — answer THAT question directly and "
+                    "concisely using only the emails below (e.g. if they asked whether they "
+                    "booked a flight, say plainly whether a flight-booking email is present, "
+                    "and name it if so — don't just describe unrelated emails instead of "
+                    "answering). If none of the emails answer their question, say so plainly "
+                    "instead of changing the subject to a generic inbox summary.\n\n"
+                    f'User\'s question: "{question}"'
+                )
+            else:
+                instruction = (
+                    "Summarize them conversationally in 2-5 short lines: name the senders and "
+                    "what each message is about, and flag anything that looks like a bill, "
+                    "receipt, or expense."
+                )
             ai_message = await llm.ainvoke(
                 [
                     SystemMessage(
                         content=(
                             "You are Nexus Prime, the user's personal assistant on Telegram. "
-                            "You just fetched emails from their inbox. Summarize them "
-                            "conversationally in 2-5 short lines: name the senders and what "
-                            "each message is about, and flag anything that looks like a bill, "
-                            "receipt, or expense. "
+                            "You just fetched emails from their inbox. "
+                            f"{instruction} "
                             "Only describe emails present in the provided JSON. Never invent, "
                             "guess, or reconstruct senders, subjects, amounts, or dates that are "
                             "not listed; if an email lacks a subject or body, say so instead of "
@@ -346,13 +366,38 @@ class ExpensePlugin:
                     }
                 )
                 if not extracted or not extracted.get("amount"):
-                    return PluginOutput(
-                        message=AIMessage(
-                            content=(
-                                "📸 I don't see a clear receipt in that photo — try a closer, "
-                                "well-lit shot of the total, or just tell me the amount in text."
+                    # The photo wasn't a (legible) receipt. Don't assume the caption
+                    # was therefore also worthless — a caption can carry its own,
+                    # independent expense ("also spent $10 on parking") even when
+                    # the photo itself doesn't. Try that before giving up.
+                    if caption:
+                        caption_extracted = await extract_expense_from_text.ainvoke(
+                            {"user_text": caption}
+                        )
+                        if caption_extracted and caption_extracted.get("amount"):
+                            return await self._finalize_expense(
+                                user_id,
+                                caption_extracted,
+                                expense_source_id(user_id, caption),
                             )
-                        ),
+
+                    # Neither the photo nor the caption yielded an expense. Say what
+                    # was actually seen instead of implying the photo was blurry/bad —
+                    # this may not be a receipt at all (e.g. a rewards/points balance),
+                    # which isn't something this bot tracks yet.
+                    description = (extracted or {}).get("description")
+                    if description:
+                        lines = [f"📸 That's not a receipt — looks like {description}."]
+                        lines.append("I don't have a way to track that yet.")
+                    else:
+                        lines = [
+                            "📸 I don't see a clear receipt in that photo — try a closer, "
+                            "well-lit shot of the total, or just tell me the amount in text."
+                        ]
+                    if caption:
+                        lines.append(f'I did note what you wrote: "{caption}" — just can\'t act on it yet.')
+                    return PluginOutput(
+                        message=AIMessage(content="\n".join(lines)),
                         state_update={"active_domain": self.name},
                     )
                 image_digest = hashlib.md5(

--- a/tests/test_email_and_expenses.py
+++ b/tests/test_email_and_expenses.py
@@ -817,3 +817,112 @@ async def test_daily_email_digest_respects_quiet_hours(monkeypatch):
     eight_am_sgt = datetime(2026, 8, 23, 0, 0, tzinfo=dt_timezone.utc)
     assert await _send_daily_email_expense_digest(user_id, eight_am_sgt) is False
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_extract_expense_from_photo_classifies_non_receipt_images(monkeypatch):
+    """Regression (#25): a non-receipt photo (e.g. a rewards/points balance) used
+    to come back as bare {"amount": None} with zero information about what was
+    actually in the image. It now carries a `description` so the caller can
+    respond honestly instead of assuming the photo was a bad/blurry receipt."""
+    import capabilities.expenses.tools as exp_tools
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "gemini_api_key", "fake-key-for-test")
+
+    class _FakeVisionMessage:
+        content = (
+            '{"amount": null, "description": "a DBS rewards points balance screenshot"}'
+        )
+
+    class _FakeVisionLLM:
+        async def ainvoke(self, messages):
+            return _FakeVisionMessage()
+
+    monkeypatch.setattr(exp_tools, "get_multimodal_llm", lambda **k: _FakeVisionLLM())
+
+    result = await exp_tools.extract_expense_from_photo.ainvoke({
+        "image_b64": "fake_b64",
+        "mime_type": "image/jpeg",
+        "caption": "Citibank and UOB points and their expiration dates",
+    })
+    assert result["amount"] is None
+    assert result["description"] == "a DBS rewards points balance screenshot"
+
+
+@pytest.mark.asyncio
+async def test_expense_plugin_photo_no_receipt_does_not_drop_caption(monkeypatch):
+    """Regression (#25): ExpensePlugin used to unconditionally treat a photo as
+    a receipt attempt and, on failure, discard the caption entirely with a
+    generic "I don't see a clear receipt" message — even when the vision model
+    correctly identified the image as something else (not a receipt) and the
+    caption held real information. The reply must now say what was actually
+    seen and must not silently drop the caption."""
+    import orchestrator.router as router_module
+    from orchestrator.router import ExpensePlugin
+    from langchain_core.messages import HumanMessage
+
+    async def fake_photo_extract(**kwargs):
+        return {"amount": None, "description": "a DBS rewards points balance screenshot"}
+
+    # The caption itself isn't a monetary expense either (also points, not spend).
+    async def fake_text_extract(**kwargs):
+        return {"amount": None}
+
+    monkeypatch.setattr(router_module.extract_expense_from_photo, "coroutine", fake_photo_extract)
+    monkeypatch.setattr(router_module.extract_expense_from_text, "coroutine", fake_text_extract)
+
+    caption = "Citibank and UOB points and their expiration dates"
+    out = await ExpensePlugin().execute({
+        "messages": [HumanMessage(content=[
+            {"type": "media", "mime_type": "image/jpeg", "data": "fake_b64"},
+            {"type": "text", "text": caption},
+        ])],
+        "user_id": 4001,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    content = str(out.message.content)
+    assert "points" in content.lower()
+    assert caption in content
+    assert "well-lit shot" not in content  # not the generic bad-photo message
+
+
+@pytest.mark.asyncio
+async def test_expense_plugin_photo_falls_back_to_caption_expense(monkeypatch):
+    """A caption CAN carry its own independent expense even when the photo
+    itself isn't a legible receipt — that must still get logged, not lost."""
+    import orchestrator.router as router_module
+    from orchestrator.router import ExpensePlugin
+    from langchain_core.messages import HumanMessage
+
+    async def fake_photo_extract(**kwargs):
+        return {"amount": None, "description": "a blurry photo"}
+
+    async def fake_text_extract(**kwargs):
+        return {
+            "amount": 10.0,
+            "currency": "SGD",
+            "merchant": "Parking",
+            "category": "Transport",
+            "date_iso": "",
+            "confidence": 0.9,
+            "needs_clarification": False,
+        }
+
+    monkeypatch.setattr(router_module.extract_expense_from_photo, "coroutine", fake_photo_extract)
+    monkeypatch.setattr(router_module.extract_expense_from_text, "coroutine", fake_text_extract)
+
+    out = await ExpensePlugin().execute({
+        "messages": [HumanMessage(content=[
+            {"type": "media", "mime_type": "image/jpeg", "data": "fake_b64"},
+            {"type": "text", "text": "also spent $10 on parking"},
+        ])],
+        "user_id": 4002,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+    # _finalize_expense returns a plain string, not an AIMessage.
+    assert "10.00" in str(out.message)
+    assert "Parking" in str(out.message)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -208,6 +208,53 @@ async def test_email_plugin_generic_inbox_ask_uses_latest_mode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_email_plugin_summary_prompt_carries_the_user_question(monkeypatch):
+    """Regression (#26): the "latest" summarizer's LLM prompt was hardcoded to a
+    generic "summarize conversationally" instruction and never received the
+    user's actual message — so a specific question like "did I book a flight"
+    got a generic inbox dump instead of an answer, even when the answer was
+    present in the fetched emails."""
+    from unittest.mock import AsyncMock
+    from langchain_core.messages import AIMessage
+    import orchestrator.router as router_module
+    import capabilities.email.tools as email_tools
+
+    async def fake_search(**kwargs):
+        return [{
+            "sender": "OCBC <alerts@ocbc.com>",
+            "subject": "Funds transfer confirmation",
+            "date": "2026-08-24T10:00:00Z",
+        }]
+
+    monkeypatch.setattr(router_module, "get_user_gmail_token", AsyncMock(return_value="mock_token"))
+    monkeypatch.setattr(router_module, "get_user_outlook_token", AsyncMock(return_value=None))
+    monkeypatch.setattr(email_tools.search_email_messages, "coroutine", fake_search)
+    monkeypatch.setattr(router_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    captured: dict = {}
+
+    class _CapturingLLM:
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return AIMessage(content="No flight booking email found in your inbox.")
+
+    monkeypatch.setattr(router_module, "get_agent_llm", lambda *a, **k: _CapturingLLM())
+
+    question = "Did I book a flight on 24 Jul? Check my outlook"
+    out = await EmailPlugin().execute({
+        "messages": [HumanMessage(content=question)],
+        "user_id": 4001,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    system_prompt = str(captured["messages"][0].content)
+    assert question in system_prompt
+    assert "answer THAT question directly" in system_prompt
+    assert "No flight booking email found" in str(out.message.content)
+
+
+@pytest.mark.asyncio
 async def test_email_plugin_scopes_financial_sweep_to_named_provider(monkeypatch):
     """Regression: "look for transactions from my outlook ... log them as expenses"
     used to search ALL connected providers merged together, silently ignoring the


### PR DESCRIPTION
## Summary

Core fixes for two P1 bugs found via real production log investigation (#25, #26).

**#25 — ExpensePlugin unconditionally treated any photo as a receipt-scan attempt.** `extract_expense_from_photo()` is now classify-first: its vision prompt explicitly decides whether the photo is actually a legible receipt before extracting anything, and when it isn't, returns a specific `description` of what it actually shows (e.g. "a DBS rewards points balance screenshot") instead of a bare `{"amount": null}`.

`ExpensePlugin.execute()`'s photo branch no longer assumes a caption is worthless just because the photo wasn't a receipt — a caption can carry its own independent expense ("also spent $10 on parking"), so that's tried via `extract_expense_from_text` before giving up. If neither the photo nor the caption yield an expense, the reply now says what was actually seen and repeats the caption content back instead of silently discarding it and implying the photo was blurry.

Credit-card-points/miles tracking itself is *not* built here — that's a separate feature discussion, not bundled into this bug fix (per explicit direction: don't assume, and don't scope-creep the fix into a new capability).

**#26 — EmailPlugin's summarizer never received the user's actual question.** `_summarize_email_results()` now gets `last_text` threaded through from both call sites; its LLM prompt directly answers the user's specific question when one is present ("did I book a flight on 24 Jul?" → a direct yes/no from the fetched emails), falling back to a general summary only for generic asks.

## Testing

- `extract_expense_from_photo`'s classification behavior, `ExpensePlugin`'s caption-preserving and caption-fallback paths, and the email summarizer prompt carrying the user's question — all verified to fail against the pre-fix code (via `git stash`) and pass against the fix.
- Full suite: 210 passed. Same 8 pre-existing failures as `main`, unrelated to this change.

Closes #25 (core fix; miles tracking to be filed separately), closes #26.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_