### PR TITLE
fix(showcase): fix mobile layout of Tasks & Reminders task cards

### DIFF
--- a/showcase/styles.css
+++ b/showcase/styles.css
@@ -4913,9 +4913,34 @@ table.financial-data-table tr:hover td {
     box-sizing: border-box !important;
   }
 
-  .task-item-card {
+  /* Regression (#29): this rule used to target a nonexistent selector with
+     the class words reversed (the markup renders ".task-card-item" — see
+     showcase/app.js), so it never applied on mobile. With no mobile
+     override, ".task-card-item" kept
+     its desktop row layout: ".task-actions-col" (Test Alert / Edit / delete,
+     flex-shrink: 0) held its full width and squeezed ".task-left-col" down to
+     ~60-90px, so ".task-title-text"'s "word-break: break-word" chopped every
+     word in the task title onto its own line. Fix the class name and make the
+     card wrap to a second row for actions instead of squeezing the title. */
+  .task-card-item {
     padding: 0.75rem 0.85rem !important;
     border-radius: 12px !important;
+    flex-wrap: wrap !important;
+  }
+
+  .task-left-col {
+    width: 100% !important;
+    flex: 1 1 100% !important;
+  }
+
+  .task-actions-col {
+    width: 100% !important;
+    flex: 1 1 100% !important;
+    flex-wrap: wrap !important;
+    justify-content: flex-start !important;
+    margin-top: 0.65rem !important;
+    padding-top: 0.65rem !important;
+    border-top: 1px dashed #222228 !important;
   }
 
   /* --------------------------------------------------------------------------

--- a/tests/test_showcase_mobile_layout.py
+++ b/tests/test_showcase_mobile_layout.py
@@ -1,0 +1,70 @@
+"""Regression (#29): the mobile stylesheet for the Tasks & Reminders Cockpit
+never actually applied.
+
+``showcase/app.js`` renders each task as ``<div class="task-card-item ...">``
+(see ``renderTasksList`` / the template around ``task-card-item``), but the
+mobile media query in ``showcase/styles.css`` targeted a nonexistent
+``.task-item-card`` selector (word order reversed). With no mobile override,
+the card kept its desktop row layout on phones: the fixed-width actions
+column (Test Alert / Edit / delete) squeezed the title column down to
+~60-90px, and ``.task-title-text``'s ``word-break: break-word`` chopped every
+word in the task title onto its own line (reported on an iPhone 17 Pro,
+issue #29).
+
+These are lightweight structural checks on the stylesheet/markup text rather
+than a rendered-DOM test, since this is a static asset with no JS test
+runner in this repo -- but they pin down the exact regression: the class
+names actually agree, and the mobile rule no longer just tweaks padding, it
+also stops the actions column from squeezing the title.
+"""
+import re
+from pathlib import Path
+
+SHOWCASE_DIR = Path(__file__).resolve().parent.parent / "showcase"
+
+
+def _read(name: str) -> str:
+    return (SHOWCASE_DIR / name).read_text()
+
+
+def _mobile_media_block(css: str) -> str:
+    """Return the body of the `@media (max-width: 900px)` block that houses
+    the Tasks & Reminders Cockpit rules (the second such block in the file --
+    the first is a smaller dashboard-grid-only block)."""
+    blocks = re.findall(r"@media \(max-width: 900px\) \{(.*?)\n\}\n", css, re.DOTALL)
+    for block in blocks:
+        if ".task-stat-card" in block:
+            return block
+    raise AssertionError("could not find the Tasks & Reminders Cockpit mobile media block")
+
+
+def test_task_card_class_names_agree_between_js_and_css():
+    """The class app.js actually renders must be the one styles.css targets."""
+    app_js = _read("app.js")
+    css = _read("styles.css")
+
+    assert '"task-card-item ' in app_js, "app.js should render task cards as task-card-item"
+    assert ".task-item-card" not in css, (
+        "styles.css still references the nonexistent '.task-item-card' class "
+        "(should be '.task-card-item', matching the markup app.js renders)"
+    )
+
+
+def test_mobile_task_card_wraps_actions_below_title():
+    """On narrow viewports the actions column must drop to its own row
+    instead of squeezing the title column down to a sliver."""
+    mobile_css = _mobile_media_block(_read("styles.css"))
+
+    task_card_rule = re.search(r"\.task-card-item\s*\{([^}]*)\}", mobile_css)
+    assert task_card_rule is not None, "no mobile .task-card-item rule found"
+    assert "flex-wrap" in task_card_rule.group(1), (
+        ".task-card-item must wrap on mobile so the actions column can drop "
+        "to a second row instead of squeezing the title"
+    )
+
+    actions_col_rule = re.search(r"\.task-actions-col\s*\{([^}]*)\}", mobile_css)
+    assert actions_col_rule is not None, "no mobile .task-actions-col rule found"
+    assert "100%" in actions_col_rule.group(1), (
+        ".task-actions-col must take the full card width on mobile so it "
+        "wraps to its own row rather than sitting beside the title"
+    )


### PR DESCRIPTION
Fixes #29.

## Root cause

`showcase/app.js` renders each task as `<div class="task-card-item ...">`, but the mobile media query (`@media (max-width: 900px)`) in `showcase/styles.css` targeted `.task-item-card` — the two words reversed — so it never matched anything and no mobile override applied.

Without a mobile override, `.task-card-item` kept its desktop row layout on phones: the fixed-width `.task-actions-col` (Test Alert / Edit / delete, `flex-shrink: 0`) held its full width and squeezed `.task-left-col` down to roughly 60-90px. `.task-title-text`'s `word-break: break-word` then chopped every word of the task title onto its own line — exactly what's shown in the issue's iPhone 17 Pro screenshot.

## Fix

- Corrected the selector to `.task-card-item`.
- Made the card wrap (`flex-wrap: wrap`) and give `.task-left-col`/`.task-actions-col` full width on mobile, so the actions row drops below the title instead of squeezing it.

## Testing

- Added `tests/test_showcase_mobile_layout.py`: structural checks that (1) the CSS class app.js renders is the one styles.css targets, and (2) the mobile rule actually makes the actions column wrap to its own row. Verified via `git stash` that both fail against the pre-fix stylesheet and pass after the fix.
- Full suite: `uv run pytest -q` → 212 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_