### PR TITLE
fix(planner): don't execute a re-plan that decided it needs to ask instead

### DIFF
--- a/orchestrator/plan_router.py
+++ b/orchestrator/plan_router.py
@@ -332,6 +332,29 @@ async def plan_dispatch(state: AssistantState) -> Command[str]:
             or deterministic_plan(text, state_with_feedback, retrieval)
         )
         _log_plan(decision)
+
+        # Regression (#34): the re-plan can legitimately decide it needs more
+        # info (decision.question set) instead of producing a better answer —
+        # e.g. verify catches "wrong bus line", re-plan realizes it doesn't
+        # know which stop the user is at. The first pass already short-circuits
+        # to asking in that case (see the `if decision.question:` block above);
+        # without the same guard here, this branch executed the capability
+        # anyway against stale/default state and shipped a wrong answer
+        # (reported: asked about bus 131, replied with directions for bus 10)
+        # instead of asking the question the planner itself decided it needed.
+        if decision.question:
+            schedule_turn_audit(decision.question)
+            return Command(
+                goto=END,
+                update={
+                    "messages": [AIMessage(content=decision.question)],
+                    "active_domain": state.get("active_domain"),
+                    "intent_type": "needs_clarification",
+                    "last_decision": decision_to_dict(decision),
+                    "plan": decision_to_dict(decision),
+                },
+            )
+
         outputs, state_updates, reply = await _execute_capabilities(decision, state)
         verify = (
             await verify_with_llm(

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -264,6 +264,77 @@ async def test_llm_planner_used_when_key_present(monkeypatch):
     assert decision.capability_ids == ["expenses"]
 
 
+@pytest.mark.asyncio
+async def test_replan_asks_question_instead_of_executing_wrong_capability(monkeypatch):
+    """Regression (#34): a re-plan (triggered by verify's needs_replan) can
+    legitimately decide it needs more info instead of a better answer -- e.g.
+    verify catches "wrong bus line", re-plan realizes it doesn't know which
+    stop the user is at. The first planning pass already short-circuits to
+    asking when decision.question is set; the retry path used to skip that
+    guard entirely and execute the capability anyway against stale state,
+    shipping a wrong answer (production repro: asked about bus 131, got
+    directions for bus 10) instead of asking the question the planner itself
+    decided it needed."""
+    from unittest.mock import AsyncMock, patch
+
+    from orchestrator.plan_router import plan_dispatch
+    from orchestrator.planner import CapabilitySelection, Decision
+    from orchestrator.router import PluginOutput
+    from orchestrator.verify import VerifyResult
+
+    first_decision = Decision(
+        capabilities=[CapabilitySelection(id="routes", reason="test", confidence=1.0)],
+        ordering=["routes"],
+        confidence=1.0,
+        source="llm",
+        retrieval_used=True,
+    )
+    replan_decision = Decision(
+        capabilities=[CapabilitySelection(id="routes", reason="test", confidence=1.0)],
+        ordering=["routes"],
+        confidence=0.8,
+        source="llm",
+        retrieval_used=True,
+        question="Which bus stop are you at?",
+    )
+
+    fake_plugin = AsyncMock()
+    fake_plugin.execute.return_value = PluginOutput(
+        message=AIMessage(content="Bus 10 runs from X to Y."),
+        state_update={},
+    )
+    fake_registry = {"routes": fake_plugin}
+
+    bad_verify = VerifyResult(
+        fulfilled=False,
+        needs_replan=True,
+        reason="wrong bus line",
+        missing="user asked about bus 131, reply was about a different bus",
+    )
+
+    state = {
+        "user_id": 1,
+        "active_domain": "routes",
+        "last_decision": None,
+        "pending_bus_stops": None,
+        "messages": [HumanMessage(content="info on bus 131 please")],
+    }
+
+    with patch("orchestrator.router.CAPABILITY_REGISTRY", fake_registry), \
+            patch(
+                "orchestrator.planner.plan_with_llm",
+                new=AsyncMock(side_effect=[first_decision, replan_decision]),
+            ), \
+            patch("orchestrator.verify.verify_with_llm", new=AsyncMock(return_value=bad_verify)):
+        command = await plan_dispatch(state)
+
+    # The capability must run once (the first attempt) and never again once
+    # the re-plan decides it needs to ask instead of answering.
+    assert fake_plugin.execute.await_count == 1
+    assert command.update["intent_type"] == "needs_clarification"
+    assert command.update["messages"][0].content == "Which bus stop are you at?"
+
+
 def test_missing_policy_excludes_retrospective_flight_queries():
     """Regression (#21): "did I book a flight on 24 Jul? Check my outlook" is an
     email lookup, not a request to book a NEW flight — but missing_policy's


### PR DESCRIPTION
Fixes #34.

## Root cause

`orchestrator/plan_router.py`'s `plan_dispatch()` checks `decision.question` and short-circuits to asking it **only on the first planning pass**. The re-plan branch (triggered when `verify.needs_replan` catches a bad reply) calls `_execute_capabilities(decision, state)` unconditionally, with no equivalent guard — so if the re-plan itself decides it needs more info (`decision.question` set), that gets silently ignored and the likely-wrong capability execution proceeds anyway.

## Real repro (from production logs, Railway)

1. User asks for the next bus for line 131.
2. First plan executes `routes`, replies with a generic answer.
3. `verify_with_llm` catches it: "Information about bus 131 -> re-planning".
4. Re-plan decides it needs more info: `capabilities: [routes]` **and** `question: "Which bus stop are you at?"`.
5. Old code: executes `routes` anyway against stale state, replies with directions for **bus 10** — wrong bus entirely. The verifier catches this too, but the bounded retry is already exhausted, so the wrong answer ships.

## Fix

Mirror the first-pass `question` guard onto the retry path.

## Testing

- Added `tests/test_planner.py::test_replan_asks_question_instead_of_executing_wrong_capability`, reproducing the exact shape (verify forces a re-plan, re-plan returns a question). Verified via `git stash` (stashing only the fix, keeping the test) that it fails against pre-fix code (capability executes twice, ships the wrong answer) and passes against the fix.
- Full suite: `uv run pytest -q` → 213 passed, 8 failed (pre-existing baseline, unrelated: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_