### PR TITLE
fix(ingress): bound LLM calls and webhook processing so a stall can't wedge the bot forever

### DIFF
--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,8 +1,18 @@
+import asyncio
+
 from fastapi import APIRouter, Request, HTTPException
-from app.ingress import telegram_ingress
+from app.ingress import send_telegram_message, telegram_ingress
 from core.config import settings
 
 router = APIRouter()
+
+# A stalled call anywhere downstream (e.g. a hung LLM request -- see
+# core/llm.py's LLM_REQUEST_TIMEOUT_SECONDS) must not hang this response
+# forever: Telegram never gets its 200 OK if we do, so it redelivers the
+# same update on its own backoff schedule, piling up duplicate in-flight
+# processing (and duplicate typing-indicator loops) for one stuck chat.
+# Comfortably under Telegram's own webhook timeout.
+WEBHOOK_PROCESSING_TIMEOUT_SECONDS = 45.0
 
 
 @router.post("/webhook")
@@ -22,5 +32,27 @@ async def receive_telegram_webhook(request: Request):
     except Exception as e:
         raise HTTPException(status_code=400, detail="Invalid JSON payload") from e
 
-    response = await telegram_ingress.handle_update(payload)
-    return response
+    try:
+        return await asyncio.wait_for(
+            telegram_ingress.handle_update(payload),
+            timeout=WEBHOOK_PROCESSING_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        # asyncio.wait_for cancels the still-running handle_update() task and
+        # waits for the cancellation to unwind before raising, so
+        # TelegramIngress.handle_update's own try/finally still runs here --
+        # the per-update typing-indicator loop gets stopped, not orphaned.
+        chat_id = (
+            (payload.get("message") or payload.get("edited_message") or {})
+            .get("chat", {})
+            .get("id")
+        )
+        if chat_id:
+            try:
+                await send_telegram_message(
+                    chat_id,
+                    "Still working on that — it's taking longer than expected. Hang tight.",
+                )
+            except Exception:  # noqa: BLE001 - never let the timeout handler itself hang the response
+                pass
+        return {"status": "ok", "processed": False, "timeout": True}

--- a/core/llm.py
+++ b/core/llm.py
@@ -7,6 +7,15 @@ from core.config import settings
 
 logger = logging.getLogger("nexus_prime.llm")
 
+# None of the four client constructions below set a request timeout, so a
+# stalled provider call (network stall, provider-side hang) can block an
+# ainvoke() indefinitely. That is fatal upstream: app/webhook.py awaits the
+# whole request-handling chain before responding to Telegram, so a single
+# hung LLM call there means the webhook never returns, Telegram never gets
+# its 200 OK, and it redelivers the same update on its own backoff schedule
+# forever -- piling up duplicate in-flight work for one stuck chat.
+LLM_REQUEST_TIMEOUT_SECONDS = 30.0
+
 class ThinkingLevel(str, Enum):
     """
     Thinking complexity tiers for DeepSeek v4 Flash agent reasoning.
@@ -55,6 +64,7 @@ def get_llm(
             model=settings.gemini_model,
             google_api_key=api_key,
             temperature=temperature,
+            timeout=LLM_REQUEST_TIMEOUT_SECONDS,
         )
 
     elif role == "agent_core":
@@ -65,6 +75,7 @@ def get_llm(
                 model=settings.gemini_model,
                 google_api_key=api_key,
                 temperature=temperature,
+                timeout=LLM_REQUEST_TIMEOUT_SECONDS,
             )
 
         api_key = settings.deepseek_api_key or "test_deepseek_key"
@@ -89,6 +100,7 @@ def get_llm(
             temperature=temperature,
             reasoning_effort=thinking_config["reasoning_effort"],
             max_tokens=thinking_config["max_tokens"],
+            timeout=LLM_REQUEST_TIMEOUT_SECONDS,
         )
 
     else:
@@ -108,6 +120,7 @@ def get_judge_llm(temperature: float = 0.0) -> ChatGoogleGenerativeAI:
         model=settings.gemini_judge_model,
         google_api_key=api_key,
         temperature=temperature,
+        timeout=LLM_REQUEST_TIMEOUT_SECONDS,
     )
 
 def get_agent_llm(

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -84,3 +84,28 @@ def test_invalid_role_raises_value_error():
     """Verify that requesting an unsupported role raises a ValueError."""
     with pytest.raises(ValueError, match="Unsupported LLM role"):
         get_llm(role="invalid_role")
+
+
+def test_all_llm_clients_have_a_bounded_request_timeout(monkeypatch):
+    """Regression (P0): none of the four client constructions set a request
+    timeout, so a stalled provider call could hang an ainvoke() forever.
+    That's fatal upstream -- app/webhook.py awaits the whole request chain
+    before responding to Telegram, so one hung LLM call meant the webhook
+    never returned, Telegram never got its 200 OK, and it redelivered the
+    same update on its own backoff schedule indefinitely (verified against
+    a real production incident: a stuck chat retried every ~60-130s for
+    10+ minutes with the typing-indicator loop never cancelled, escalating
+    to a sendChatAction 429 storm)."""
+    from core.config import settings
+    from core.llm import LLM_REQUEST_TIMEOUT_SECONDS
+
+    assert LLM_REQUEST_TIMEOUT_SECONDS is not None and LLM_REQUEST_TIMEOUT_SECONDS > 0
+
+    assert get_llm(role="multimodal_io").timeout == LLM_REQUEST_TIMEOUT_SECONDS
+    assert get_judge_llm().timeout == LLM_REQUEST_TIMEOUT_SECONDS
+
+    monkeypatch.setattr(settings, "llm_provider", "gemini")
+    assert get_llm(role="agent_core").timeout == LLM_REQUEST_TIMEOUT_SECONDS
+
+    monkeypatch.setattr(settings, "llm_provider", "deepseek")
+    assert get_agent_llm().request_timeout == LLM_REQUEST_TIMEOUT_SECONDS

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -61,6 +61,48 @@ def test_webhook_callback_query_resume():
     assert response.status_code == 200
     assert response.json()["resumed"] is True
 
+def test_webhook_times_out_instead_of_hanging_forever(monkeypatch):
+    """Regression (P0, production incident): a hung downstream call (e.g. a
+    stalled LLM request -- see core/llm.py's LLM_REQUEST_TIMEOUT_SECONDS)
+    must not hang the webhook response forever. Before this fix,
+    receive_telegram_webhook fully awaited handle_update() with no
+    timeout anywhere in the chain -- if handle_update never completed,
+    the webhook never returned, Telegram never got its 200 OK, and it
+    redelivered the same update on its own backoff schedule indefinitely.
+    Verified against a real incident: the same chat was redelivered every
+    ~60-130s for 10+ minutes with zero replies ever sent, while each
+    redelivery's never-cancelled typing-indicator loop piled up until
+    Telegram's sendChatAction calls were failing with 429s dozens/sec."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    import app.webhook as webhook_module
+    from app.ingress import telegram_ingress
+
+    monkeypatch.setattr(webhook_module, "WEBHOOK_PROCESSING_TIMEOUT_SECONDS", 0.05)
+
+    async def _hang(payload):
+        await asyncio.sleep(999)
+
+    monkeypatch.setattr(telegram_ingress, "handle_update", _hang)
+    monkeypatch.setattr(webhook_module, "send_telegram_message", AsyncMock(return_value=True))
+
+    payload = {
+        "update_id": 10004,
+        "message": {
+            "message_id": 503,
+            "from": {"id": 9002, "first_name": "Test"},
+            "chat": {"id": 9002, "type": "private"},
+            "text": "Can you see if there are any flight bookings in my email",
+        },
+    }
+    response = client.post("/api/webhook", json=payload, headers=_webhook_headers())
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body.get("timeout") is True
+
+
 def test_webhook_jobs_command():
     payload = {
         "update_id": 10003,


### PR DESCRIPTION
Fixes #38.

## Root cause

1. `app/webhook.py` fully `await`s `telegram_ingress.handle_update(payload)` before returning any HTTP response — no per-request timeout anywhere in that path.
2. `core/llm.py`'s four LLM client constructions set no `timeout` — a stalled provider call can hang an `ainvoke()` indefinitely.
3. Because the webhook handler never completes, Telegram never gets its 200 OK and keeps redelivering the same update on its own backoff schedule.
4. Each redelivered attempt spins up its own `_typing_loop` task that only gets cancelled in `handle_update`'s `try/finally` after processing completes — which never happens for a hung call, so these accumulate.

Real production repro: chat `149917165`'s "Can you see if there are any flight bookings in my email" was redelivered every ~60-130s for 10+ minutes with zero replies sent, `sendChatAction` eventually failing with escalating 429s. Mitigated live by a manual service restart (not a fix).

## Fix

- `core/llm.py`: every client construction now sets an explicit 30s request timeout (`LLM_REQUEST_TIMEOUT_SECONDS`).
- `app/webhook.py`: wraps `telegram_ingress.handle_update()` in `asyncio.wait_for(timeout=45s)`. `asyncio.wait_for` cancels and awaits the inner task before raising, so `handle_update`'s own `try/finally` still runs during that unwind — the typing loop gets stopped, not orphaned. On timeout the webhook still ACKs and best-effort tells the user it's still working.

## Testing

- `tests/test_llm_factory.py::test_all_llm_clients_have_a_bounded_request_timeout` — all four client constructions carry the bounded timeout.
- `tests/test_webhook.py::test_webhook_times_out_instead_of_hanging_forever` — a hung `handle_update()` still returns within the wrapped timeout instead of hanging.
- Verified via `git stash` (stashing only the source fix, keeping the tests) that both fail against pre-fix code and pass against the fix.
- Full suite: `uv run pytest -q` → 215 passed, 8 failed (pre-existing baseline, unrelated: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm6kdhdWSd7ctwvWLAVRmy)_