### PR TITLE
fix(showcase): cache-bust styles.css by content hash, not a forgettable counter

### DIFF
--- a/showcase/index.html
+++ b/showcase/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   
-  <link rel="stylesheet" href="styles.css?v=37" />
+  <link rel="stylesheet" href="styles.css?v=9b71162318" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡</text></svg>" />
 </head>
 <body>

--- a/tests/test_showcase_cache_busting.py
+++ b/tests/test_showcase_cache_busting.py
@@ -1,0 +1,49 @@
+"""Regression (#29 reopened): a merged CSS fix didn't actually reach phones.
+
+PR #33 fixed the mobile ``.task-card-item`` selector bug in
+``showcase/styles.css``, deployed to production, and the owner still saw
+the broken layout minutes later. Root cause (confirmed against Railway
+deploy history: commit c55ade2 was live well before the "still there"
+report): ``showcase/index.html`` cache-busts ``styles.css`` with a manual
+``?v=N`` query param (see git history -- every prior CSS-affecting change
+bumped it), but PR #33 edited ``styles.css`` without bumping it. Mobile
+Safari kept serving its already-cached, pre-fix copy of the stylesheet
+from the same URL indefinitely.
+
+Fix: make the query param a content hash instead of a manually-tracked
+counter, so it is *impossible* to ship a stylesheet change without also
+changing the URL clients fetch it from -- closing this whole bug class
+rather than just this one instance of it.
+"""
+import hashlib
+import re
+from pathlib import Path
+
+SHOWCASE_DIR = Path(__file__).resolve().parent.parent / "showcase"
+HASH_LEN = 10
+
+
+def _read(name: str) -> str:
+    return (SHOWCASE_DIR / name).read_text()
+
+
+def _content_hash(name: str) -> str:
+    return hashlib.sha256((SHOWCASE_DIR / name).read_bytes()).hexdigest()[:HASH_LEN]
+
+
+def test_styles_css_cache_bust_matches_file_content():
+    """index.html's styles.css query param must equal a hash of the file's
+    actual current content, so any future edit to styles.css necessarily
+    changes the URL and can't be served stale from a client cache."""
+    index_html = _read("index.html")
+    match = re.search(r'href="styles\.css\?v=([^"]+)"', index_html)
+    assert match is not None, "index.html should link styles.css with a ?v= cache-busting param"
+
+    expected = _content_hash("styles.css")
+    assert match.group(1) == expected, (
+        "showcase/index.html references styles.css with a stale cache-busting "
+        f"value ({match.group(1)!r}); it must be the file's current content "
+        f"hash ({expected!r}) or clients with a cached copy will never see "
+        "the new stylesheet (this is exactly how #29 stayed broken after "
+        "PR #33 merged and deployed)"
+    )


### PR DESCRIPTION
Fixes #29.

## Root cause

Issue #29 was reopened minutes after PR #33 merged and deployed — the owner still saw the broken mobile task-card layout. Railway deploy history confirms commit `c55ade2` (PR #33's fix) was already live in production before the "still there" report, so the CSS fix itself was correct but never reached the client.

`showcase/index.html` cache-busts static assets with a manually incremented `?v=N` query param — an established convention (git history shows prior CSS-affecting commits bumping `styles.css`'s `v` each time). PR #33 edited `styles.css` but never bumped `v=37`, so clients with an already-cached copy of `styles.css?v=37` (mobile Safari in particular) kept serving the stale, pre-fix stylesheet from the exact same URL indefinitely.

## Fix

Replace the manual counter with a content hash of `styles.css`, so the URL is structurally incapable of staying the same across a content change — this closes the whole bug class (forgetting to bump the cache-buster) rather than just this one instance.

## Testing

- Added `tests/test_showcase_cache_busting.py`: asserts `index.html`'s `styles.css?v=` equals `sha256(styles.css)[:10]`. Verified via `git stash` that it fails against the pre-fix `index.html` (`?v=37`, a stale manual counter) and passes against the fix.
- Full suite: `uv run pytest -q` → 216 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_