### PR TITLE
fix(general): stop shipping hallucinated links when search_web/fetch_url go uncalled

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -857,6 +857,9 @@ class RecipePlugin:
         return PluginOutput(message=reply, state_update={"active_domain": self.name})
 
 
+URL_PATTERN = re.compile(r"https?://\S+")
+
+
 class GeneralPlugin:
     """General capability plugin: handles factual queries and casual conversation with DeepSeek v4 Flash + Tavily."""
 
@@ -968,23 +971,29 @@ class GeneralPlugin:
                 state_update={"active_domain": self.name},
             )
 
-        try:
-            llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7)
-            llm_with_tools = llm.bind_tools(available_tools)
-            ai_message = await llm_with_tools.ainvoke(history)
+        MAX_TOOL_ROUNDS = 3
 
-            MAX_TOOL_ROUNDS = 3
+        async def _run_tool_loop(hist: list) -> tuple[str, bool]:
+            """Runs the bounded tool-call loop against `hist` in place and
+            returns (final_text, link_tool_used). link_tool_used is True only
+            if search_web or fetch_url actually ran this pass, so a raw URL
+            in final_text with link_tool_used=False is provably unverified
+            rather than sourced from a real search/fetch."""
+            link_tool_used = False
+            ai_message = await llm_with_tools.ainvoke(hist)
             for _round in range(MAX_TOOL_ROUNDS):
                 tool_calls = getattr(ai_message, "tool_calls", None) or []
                 if not tool_calls:
                     break
-                history.append(ai_message)
+                hist.append(ai_message)
                 for call in tool_calls:
                     call_name = str(call.get("name") or "")
                     call_args = dict(call.get("args") or {})
                     if call_name == "query_transactions":
                         # Identity guard: never trust a model-supplied user_id.
                         call_args["user_id"] = int(user_id or 0)
+                    if call_name in ("search_web", "fetch_url"):
+                        link_tool_used = True
                     tool_obj = next((t for t in available_tools if t.name == call_name), None)
                     if tool_obj is None:
                         observation: Any = f"[{call_name}] Unknown tool."
@@ -994,29 +1003,68 @@ class GeneralPlugin:
                         except Exception as tool_exc:  # noqa: BLE001
                             print(f"[GENERAL] tool {call_name} failed: {tool_exc}")
                             observation = f"[{call_name}] failed: {tool_exc}"
-                    history.append(
+                    hist.append(
                         ToolMessage(
                             content=str(observation),
                             tool_call_id=str(call.get("id") or call_name),
                         )
                     )
-                ai_message = await llm_with_tools.ainvoke(history)
+                ai_message = await llm_with_tools.ainvoke(hist)
 
-            content = extract_llm_text(getattr(ai_message, "content", "")).strip()
-            if not content:
-                if getattr(ai_message, "tool_calls", None):
-                    history.append(ai_message)
-                    for call in ai_message.tool_calls:
-                        history.append(
-                            ToolMessage(
-                                content="[tool] Round budget exhausted; answer from what you have.",
-                                tool_call_id=str(call.get("id") or call.get("name") or ""),
-                            )
+            text = extract_llm_text(getattr(ai_message, "content", "")).strip()
+            if not text and getattr(ai_message, "tool_calls", None):
+                hist.append(ai_message)
+                for call in ai_message.tool_calls:
+                    hist.append(
+                        ToolMessage(
+                            content="[tool] Round budget exhausted; answer from what you have.",
+                            tool_call_id=str(call.get("id") or call.get("name") or ""),
                         )
-                    final_message = await llm.ainvoke(history)
-                    content = extract_llm_text(getattr(final_message, "content", "")).strip()
-                if not content:
-                    content = self._generate_rule_based_response(last_text)
+                    )
+                final_message = await llm.ainvoke(hist)
+                text = extract_llm_text(getattr(final_message, "content", "")).strip()
+            return text, link_tool_used
+
+        try:
+            llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7)
+            llm_with_tools = llm.bind_tools(available_tools)
+            content, link_tool_used = await _run_tool_loop(history)
+
+            # Regression (#42, #43): asked directly for a link, the model
+            # fabricated one (a plausible-looking Instagram reel URL; dead
+            # Foodadvisor/Burpple/Tripadvisor links) instead of calling
+            # search_web/fetch_url -- confirmed against real production logs
+            # with both tools already available. A raw http(s) URL in the
+            # final reply that this pass never backed with an actual
+            # search_web/fetch_url call is unverifiable and very likely
+            # invented, so nudge for one corrective retry rather than ship it.
+            if content and URL_PATTERN.search(content) and not link_tool_used:
+                history.append(
+                    SystemMessage(
+                        content=(
+                            "Your draft reply included a link, but you did not call "
+                            "search_web or fetch_url this turn -- that link is "
+                            "unverified and must not be sent as-is. Call search_web "
+                            "or fetch_url now to find a real link, or rewrite your "
+                            "reply without inventing one."
+                        )
+                    )
+                )
+                retried_content, link_tool_used = await _run_tool_loop(history)
+                if retried_content:
+                    content = retried_content
+                if URL_PATTERN.search(content) and not link_tool_used:
+                    # Still no real tool call backing the link after one nudge
+                    # -- strip it rather than ship a link that's provably
+                    # unverified.
+                    content = URL_PATTERN.sub("", content).strip()
+                    content += (
+                        "\n\n(I don't have a verified link for that right now "
+                        "-- want me to search for one?)"
+                    )
+
+            if not content:
+                content = self._generate_rule_based_response(last_text)
         except Exception as exc:  # noqa: BLE001 - never let LLM errors kill the webhook
             print(f"[GENERAL] LLM/tool loop failed, using fallback: {exc}")
             content = self._generate_rule_based_response(last_text)

--- a/tests/test_general_url_guard.py
+++ b/tests/test_general_url_guard.py
@@ -1,0 +1,137 @@
+"""Regression (#42, #43): the model was asked directly for a link and
+fabricated one -- a plausible-looking Instagram reel URL, dead
+Foodadvisor/Burpple/Tripadvisor links -- instead of calling
+search_web/fetch_url. Confirmed against real production logs (both bugs
+occurred *after* fetch_url (#22/PR #41) was already deployed, so the tool
+existed and simply wasn't invoked).
+
+GeneralPlugin.execute() now tracks whether search_web/fetch_url actually ran
+this turn; a raw http(s) URL in the reply without either tool having run
+triggers one corrective retry (an explicit reminder to call a real tool or
+drop the link), and if that retry still produces an unverified URL, it gets
+stripped rather than shipped.
+"""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from orchestrator.router import GeneralPlugin
+
+USER_ID = 5252
+
+
+class _ScriptedToolLLM:
+    """Replays a fixed sequence of AIMessage responses, one per ainvoke call."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        self.calls += 1
+        idx = min(self.calls - 1, len(self._responses) - 1)
+        return self._responses[idx]
+
+
+def _tool_call(name, call_id, query="claypot chicken rice orchard towers"):
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": name, "args": {"query": query}, "id": call_id, "type": "tool_call"}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_link_stripped_when_no_tool_ever_called(monkeypatch):
+    """Exact #42/#43 shape: the model never calls search_web or fetch_url at
+    all, even after the corrective nudge -- the fabricated link must not
+    reach the user."""
+    import orchestrator.router as router_module
+
+    llm = _ScriptedToolLLM([
+        AIMessage(content="here's a reel about it! https://www.instagram.com/reel/DN9-WtLAZHk"),
+        AIMessage(content="here's a link: https://www.foodadvisor.com.sg/restaurant/fake-listing"),
+    ])
+    monkeypatch.setattr(router_module, "get_agent_llm", lambda *a, **k: llm)
+    monkeypatch.setattr(router_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    output = await GeneralPlugin().execute({
+        "user_id": USER_ID,
+        "messages": [HumanMessage(content="Can send me the claypot chicken rice link?")],
+    })
+
+    reply = str(output.message.content)
+    assert "http" not in reply, f"unverified URL leaked into the reply: {reply!r}"
+    assert "verified link" in reply.lower()
+    assert llm.calls == 2, "should have retried exactly once after the nudge"
+
+
+@pytest.mark.asyncio
+async def test_real_search_backed_link_passes_through_untouched(monkeypatch):
+    """When the model calls search_web and the link comes from its result,
+    nothing should be stripped or retried."""
+    import capabilities.general.tools as general_tools
+    import orchestrator.router as router_module
+
+    class _SpySearchTool:
+        name = "search_web"
+        calls = 0
+
+        async def ainvoke(self, args):
+            type(self).calls += 1
+            return "Summary: found it.\n- Claypot Rice (https://real-search-result.example.com/page): great reviews"
+
+    monkeypatch.setattr(general_tools, "search_web", _SpySearchTool())
+    llm = _ScriptedToolLLM([
+        _tool_call("search_web", "call_1"),
+        AIMessage(content="here's a real link: https://real-search-result.example.com/page"),
+    ])
+    monkeypatch.setattr(router_module, "get_agent_llm", lambda *a, **k: llm)
+    monkeypatch.setattr(router_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    output = await GeneralPlugin().execute({
+        "user_id": USER_ID,
+        "messages": [HumanMessage(content="Can send me the claypot chicken rice link?")],
+    })
+
+    reply = str(output.message.content)
+    assert "https://real-search-result.example.com/page" in reply
+    assert _SpySearchTool.calls == 1
+    assert llm.calls == 2, "no corrective retry should fire when a tool actually backed the link"
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_once_model_actually_calls_search(monkeypatch):
+    """First pass hallucinates with no tool call (triggers the guard); the
+    corrective retry then genuinely calls search_web and the real result
+    should ship, not get stripped."""
+    import capabilities.general.tools as general_tools
+    import orchestrator.router as router_module
+
+    class _SpySearchTool:
+        name = "search_web"
+        calls = 0
+
+        async def ainvoke(self, args):
+            type(self).calls += 1
+            return "Summary: found it.\n- Isle Eating House (https://real-foodblog.example.com/isle): great reviews"
+
+    monkeypatch.setattr(general_tools, "search_web", _SpySearchTool())
+    llm = _ScriptedToolLLM([
+        AIMessage(content="here's a link: https://www.foodadvisor.com.sg/fake"),  # pass 1: hallucinated, no tool
+        _tool_call("search_web", "call_1"),  # pass 2, round 1: now actually searches
+        AIMessage(content="found it: https://real-foodblog.example.com/isle"),  # pass 2, round 2: real answer
+    ])
+    monkeypatch.setattr(router_module, "get_agent_llm", lambda *a, **k: llm)
+    monkeypatch.setattr(router_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    output = await GeneralPlugin().execute({
+        "user_id": USER_ID,
+        "messages": [HumanMessage(content="Any links")],
+    })
+
+    reply = str(output.message.content)
+    assert "https://real-foodblog.example.com/isle" in reply
+    assert "foodadvisor.com.sg/fake" not in reply
+    assert _SpySearchTool.calls == 1


### PR DESCRIPTION
Fixes #42. Fixes #43.

## Root cause

Two P1 audit reports, confirmed via real Railway production logs (deployment `1ab8ab2f`, commit `3a9cf940` — i.e. *after* `fetch_url` (#22/PR #41) was already live, so the tool existed and simply wasn't invoked):

- **#42**: "Can send me the claypot chicken rice link?" → assistant replied with a plausible-looking but fabricated Instagram reel URL (`instagram.com/reel/DN9-WtLAZHk`), no `search_web`/`fetch_url` call in the trace.
- **#43**: "Any links" (about Isle Eating House) → assistant replied with three fabricated Foodadvisor/Burpple/Tripadvisor URLs, again with zero tool calls in the trace.

In both cases the planner correctly routed to `general` and the model had `search_web` and `fetch_url` available and bound — it simply chose to answer from parametric memory instead of calling either.

## Fix

`GeneralPlugin`'s bounded tool loop (`orchestrator/router.py`) now tracks whether `search_web`/`fetch_url` actually ran this turn. A raw `http(s)` URL in the final reply that isn't backed by either tool call is provably unverified, so it now triggers one corrective retry (an explicit system reminder that the link must come from a real tool call or be dropped) before shipping. If the retry still produces an unbacked URL, the URL is stripped and replaced with an honest "I don't have a verified link" note rather than silently forwarding a possibly dead/fabricated link. A link that IS backed by an actual `search_web`/`fetch_url` call passes straight through, untouched, on the first pass.

## Testing

- Added `tests/test_general_url_guard.py`: the exact #42/#43 shape (never calls a tool, even after the nudge → link stripped), a search-backed link passing through unmodified with no retry, and a retry that succeeds because the second pass genuinely calls `search_web`. Verified via `git stash` that the two guard-dependent tests fail against pre-fix code and all pass against the fix.
- Full suite: `uv run pytest -q` → 225 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_