### PR TITLE
fix(whiteboard): bound planning-intake's total latency under the webhook timeout

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1260,6 +1260,28 @@ class ReminderPlugin:
         )
 
 
+# Regression: _planning_intake() chains a comprehend_request() LLM call
+# (bounded to LLM_REQUEST_TIMEOUT_SECONDS=30s, see core/llm.py) followed by a
+# concurrent research pass (each query bounded to RESEARCH_QUERY_TIMEOUT_SECONDS
+# below) -- each step is individually bounded, but nothing bounded their SUM,
+# so a slow-but-within-budget LLM/search response on both steps could
+# legitimately take up to ~45-55s combined, blowing straight past the
+# webhook's own 45s ceiling (app/webhook.py's WEBHOOK_PROCESSING_TIMEOUT_SECONDS).
+# Production repro: "bring up the upcoming bali trip" set active_domain to
+# whiteboard, and every subsequent message -- even unrelated ones like "this
+# is broken", since _parse_intent() can't match them to a fast path either --
+# re-entered this same expensive, unbounded-as-a-whole pipeline, so the user
+# got the generic "Still working on that" webhook-timeout fallback on every
+# single turn with zero real progress. PLANNING_INTAKE_TIMEOUT_SECONDS bounds
+# the whole pipeline safely under the webhook ceiling so a slow turn fails
+# fast with an honest, on-topic message instead of silently re-running into
+# the same wall every time; RESEARCH_QUERY_TIMEOUT_SECONDS is tightened from
+# its prior 25s so a slow comprehend_request() call still leaves the research
+# pass a realistic chance to finish inside the outer bound.
+PLANNING_INTAKE_TIMEOUT_SECONDS = 35.0
+RESEARCH_QUERY_TIMEOUT_SECONDS = 15.0
+
+
 class WhiteboardPlugin:
     """Conversational whiteboard capability: create boards, list them, summarize,
     pin notes, and add checklist cards — backed by the shared whiteboard tools."""
@@ -1454,8 +1476,21 @@ class WhiteboardPlugin:
                 reply = f"📌 Pinned to {board.emoji_icon} *{board.title}* (#{board.id}) as card #{block.id}."
             return PluginOutput(message=AIMessage(content=reply), state_update={"active_domain": self.name})
 
-        # action is None → deep-reasoning planning intake (create/augment from freeform text)
-        planned = await self._planning_intake(user_id, last_text)
+        # action is None → deep-reasoning planning intake (create/augment from freeform text).
+        # Bounded well under the webhook's own timeout -- see PLANNING_INTAKE_TIMEOUT_SECONDS.
+        try:
+            planned = await asyncio.wait_for(
+                self._planning_intake(user_id, last_text),
+                timeout=PLANNING_INTAKE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return PluginOutput(
+                message=AIMessage(content=(
+                    "🎨 Still pulling that together — it's taking longer than expected. "
+                    "Try asking again in a moment, or say *\"my boards\"* to see what's there already."
+                )),
+                state_update={"active_domain": self.name},
+            )
         if planned is not None:
             return PluginOutput(
                 message=AIMessage(content=planned),
@@ -1593,7 +1628,7 @@ class WhiteboardPlugin:
             async def _run(query: str):
                 try:
                     return query, await asyncio.wait_for(
-                        search_web.ainvoke({"query": query}), timeout=25
+                        search_web.ainvoke({"query": query}), timeout=RESEARCH_QUERY_TIMEOUT_SECONDS
                     )
                 except Exception as exc:  # noqa: BLE001
                     return query, f"[search failed: {exc}]"

--- a/tests/test_whiteboard.py
+++ b/tests/test_whiteboard.py
@@ -744,6 +744,53 @@ async def test_planning_intake_augments_recent_board_and_researches(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_planning_intake_fails_fast_instead_of_hanging_past_webhook_timeout(monkeypatch):
+    """Regression: a real production incident where "bring up the upcoming
+    bali trip" -- and then every unrelated follow-up message, since none
+    matched a fast _parse_intent path either -- got stuck re-running
+    _planning_intake() on every single turn, each one silently taking longer
+    than the webhook's own 45s timeout with zero real progress ("Still
+    working on that" forever). comprehend_request() and the research pass
+    were each individually bounded, but nothing bounded their sum, so a slow
+    (but within-budget) response from either could exceed the outer webhook
+    deadline. WhiteboardPlugin.execute() must now fail fast with an honest
+    message well under that ceiling instead of hanging."""
+    import asyncio
+    from capabilities.whiteboard import planner as wb_planner
+    import orchestrator.router as router_module
+    from orchestrator.router import WhiteboardPlugin
+    from orchestrator.state import AssistantState
+    from langchain_core.messages import HumanMessage
+
+    # Tiny bound so the test itself stays fast while still exercising real
+    # asyncio.wait_for cancellation, not a mock of it.
+    monkeypatch.setattr(router_module, "PLANNING_INTAKE_TIMEOUT_SECONDS", 0.05)
+
+    async def slow_comprehend(text, board_context=None):
+        await asyncio.sleep(0.3)  # well past the 0.05s bound above
+        return {"action": "none"}  # never reached
+
+    monkeypatch.setattr(wb_planner, "comprehend_request", slow_comprehend)
+
+    plugin = WhiteboardPlugin()
+    state = AssistantState(
+        messages=[HumanMessage(content="can you bring up the upcoming bali trip for me to plan some stuff")],
+        user_id=7701,
+    )
+
+    loop = asyncio.get_event_loop()
+    started = loop.time()
+    res = await plugin.execute(state)
+    elapsed = loop.time() - started
+
+    assert elapsed < 0.2, f"execute() should fail fast at the bound, not wait out the full hang ({elapsed}s)"
+    body = res.message.content
+    assert "taking longer than expected" in body
+    assert "Created" not in body
+    assert res.state_update == {"active_domain": "whiteboard"}
+
+
+@pytest.mark.asyncio
 async def test_dispatch_reroutes_whiteboard_followups():
     """With active_domain=whiteboard, planning-signal follow-ups stay on the board."""
     from orchestrator.router import CapabilityRouter


### PR DESCRIPTION
Fixes the live incident just reported: "can you bring up the upcoming bali trip for me to plan some stuff" got "Still working on that — it's taking longer than expected. Hang tight." — and then every single follow-up message got the exact same reply, on every turn, for 5+ minutes straight.

## Root cause

Confirmed via Railway logs: every `POST /api/webhook` for this chat after the first message took ~45.6-45.8s — consistently landing right at `app/webhook.py`'s own `WEBHOOK_PROCESSING_TIMEOUT_SECONDS=45` ceiling, not varying the way a true indefinite hang would.

`WhiteboardPlugin._planning_intake()` chains a `comprehend_request()` LLM call (individually bounded to `LLM_REQUEST_TIMEOUT_SECONDS=30s`, see `core/llm.py`) followed by a concurrent research pass (each query individually bounded to what was a 25s timeout) — each step is bounded on its own, but nothing bounded their **sum**, so a slow-but-within-budget response on both steps could legitimately take up to ~55s combined, blowing past the outer 45s webhook deadline every time.

And because "bring up the bali trip" set `active_domain` to `whiteboard`, every subsequent message — even totally unrelated ones — re-entered this same expensive, unbounded-as-a-whole pipeline: `WhiteboardPlugin._parse_intent()` can't match "this is broken" or "is it not working?" to any fast path (list/pin/add_card/summary/create), so `action` stays `None` and every one of them fell through into the same slow `_planning_intake()` call, hitting the same wall each time.

## Fix

Same "bound every layer" pattern as #39:
- `orchestrator/router.py`: `PLANNING_INTAKE_TIMEOUT_SECONDS=35s` now wraps the whole `_planning_intake()` call in `asyncio.wait_for`. On timeout, `WhiteboardPlugin.execute()` returns an honest "still pulling that together, try again in a moment" reply instead of silently re-running into the same 45s wall.
- `RESEARCH_QUERY_TIMEOUT_SECONDS=15s` (down from the prior inline 25s) gives the research pass a real chance to finish inside the new outer bound even when `comprehend_request()` itself ran slow.

## Testing

- Added `tests/test_whiteboard.py::test_planning_intake_fails_fast_instead_of_hanging_past_webhook_timeout`: a real (not mocked) `asyncio.wait_for` exercise with the bound monkeypatched down to 0.05s and `comprehend_request()` sleeping 0.3s, asserting `execute()` returns in <0.2s with the graceful fallback message. Verified via `git stash` (router.py changes only, keeping the new test) that it fails against pre-fix code and passes against the fix.
- Full suite: `uv run pytest -q` → 226 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_