### PR TITLE
fix(webhook): surface timeout incidents to the audit/bug pipeline instead of dropping them silently

### DIFF
--- a/app/webhook.py
+++ b/app/webhook.py
@@ -55,4 +55,27 @@ async def receive_telegram_webhook(request: Request):
                 )
             except Exception:  # noqa: BLE001 - never let the timeout handler itself hang the response
                 pass
+        # Regression: this cancellation happens mid-flight through
+        # handle_update(), before plan_dispatch() ever reaches the point
+        # where it schedules a conversation audit -- so a run of webhook
+        # timeouts was previously invisible to every audit/monitoring path
+        # (confirmed live: 5 consecutive timeouts for one chat, zero audit
+        # entries). Report it explicitly instead of leaving it silent.
+        try:
+            from core.audit import record_operation_event
+
+            await record_operation_event(
+                subsystem="webhook",
+                error_context=(
+                    f"Webhook processing exceeded {WEBHOOK_PROCESSING_TIMEOUT_SECONDS}s "
+                    f"and was cancelled (chat_id={chat_id})."
+                ),
+                detection_source="webhook_timeout",
+                user_id=chat_id,
+                fingerprint="op_webhook_processing_timeout",
+                severity="P1",
+                title="Webhook processing repeatedly exceeds its own timeout",
+            )
+        except Exception:  # noqa: BLE001 - audit reporting must never break the timeout response
+            pass
         return {"status": "ok", "processed": False, "timeout": True}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -103,6 +103,53 @@ def test_webhook_times_out_instead_of_hanging_forever(monkeypatch):
     assert body.get("timeout") is True
 
 
+def test_webhook_timeout_reports_an_operation_event(monkeypatch):
+    """Regression: a webhook-level timeout cancels handle_update() before
+    plan_dispatch() ever reaches schedule_turn_audit(), so a run of repeated
+    timeouts was invisible to every audit/monitoring path (confirmed live:
+    5 consecutive timeouts for one chat, zero audit entries -- the owner
+    asked why the auto-audit never picked it up). The timeout handler must
+    now explicitly report the incident through record_operation_event so it
+    surfaces as a tracked (deduplicated) production bug instead of silently
+    vanishing."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    import app.webhook as webhook_module
+    import core.audit as audit_module
+    from app.ingress import telegram_ingress
+
+    monkeypatch.setattr(webhook_module, "WEBHOOK_PROCESSING_TIMEOUT_SECONDS", 0.05)
+
+    async def _hang(payload):
+        await asyncio.sleep(999)
+
+    monkeypatch.setattr(telegram_ingress, "handle_update", _hang)
+    monkeypatch.setattr(webhook_module, "send_telegram_message", AsyncMock(return_value=True))
+    fake_record = AsyncMock(return_value=None)
+    monkeypatch.setattr(audit_module, "record_operation_event", fake_record)
+
+    payload = {
+        "update_id": 10005,
+        "message": {
+            "message_id": 504,
+            "from": {"id": 9003, "first_name": "Test"},
+            "chat": {"id": 9003, "type": "private"},
+            "text": "bring up the upcoming bali trip for me to plan some stuff",
+        },
+    }
+    response = client.post("/api/webhook", json=payload, headers=_webhook_headers())
+    assert response.status_code == 200
+    assert response.json().get("timeout") is True
+
+    assert fake_record.await_count == 1
+    call_kwargs = fake_record.await_args.kwargs
+    assert call_kwargs["detection_source"] == "webhook_timeout"
+    assert call_kwargs["user_id"] == 9003
+    assert call_kwargs["fingerprint"] == "op_webhook_processing_timeout"
+    assert call_kwargs["severity"] == "P1"
+
+
 def test_webhook_jobs_command():
     payload = {
         "update_id": 10003,


### PR DESCRIPTION
Follow-up to #45 (whiteboard planning-intake timeout): the owner asked why the auto-audit never picked up 5 consecutive "Still working on that" webhook timeouts in that live incident.

## Root cause

`app/webhook.py`'s `asyncio.wait_for()` cancels `handle_update()` mid-flight on timeout. `schedule_turn_audit()` only ever runs from deep inside `plan_dispatch()`, after a capability has actually produced a reply — a cancelled turn never reaches that point, so it was completely invisible to every audit/monitoring path.

## Fix

The timeout except-block now reports the incident directly through `core/audit.py`'s `record_operation_event()` (the same no-LLM-triage, fingerprint-deduplicated pipeline `core/scheduler.py`'s ops-health sweep already uses) — a stable fingerprint (`op_webhook_processing_timeout`) so repeated timeouts dedupe into one tracked, occurrence-counted issue instead of spamming one per chat per timeout. Best-effort: wrapped in its own try/except so a failure in audit reporting can never break the timeout response itself.

## Testing

- Added `test_webhook_timeout_reports_an_operation_event`: mirrors the existing timeout regression test's monkeypatch-hang pattern, spies on `record_operation_event`, and asserts it's awaited once with `detection_source="webhook_timeout"`, the right chat's `user_id`, the stable fingerprint, and `severity="P1"`. Verified via `git stash` that it fails against pre-fix code and passes against the fix.
- Full suite: `uv run pytest -q` → 227 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_