### PR TITLE
fix(whiteboard): fix add_match's missing word boundary around to/on

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1352,8 +1352,14 @@ class WhiteboardPlugin:
                 "board_ref": self._extract_board_ref("pin to " + pin_match.group(2).strip()),
             }
 
+        # Regression (#48): "to"/"on" here lacked word boundaries, so they could
+        # match as a bare substring inside an unrelated word -- e.g. "add the
+        # location can you provide..." matched on "locati|ON|", splitting
+        # content="the locati" and board_ref="can you provide...", instead of
+        # correctly falling through to no match at all. pin_match (below)
+        # already guards this correctly with \b(?:to|on)\b; add_match didn't.
         add_match = re.search(
-            r"\badd\s+(?:a\s+)?(note|checklist|card|todo|to-do)?\s*(.*?)\s*(?:to|on)\s+(?:my|the|our)?\s*(.+?)\s*(?:boards?|whiteboards?|canvas)?\s*$",
+            r"\badd\s+(?:a\s+)?(note|checklist|card|todo|to-do)?\s*(.*?)\s*\b(?:to|on)\b\s+(?:my|the|our)?\s*(.+?)\s*(?:boards?|whiteboards?|canvas)?\s*$",
             raw,
             re.IGNORECASE,
         )

--- a/tests/test_whiteboard.py
+++ b/tests/test_whiteboard.py
@@ -743,6 +743,70 @@ async def test_planning_intake_augments_recent_board_and_researches(monkeypatch)
     assert research_card["content_payload"]["topics"][0]["sources"][0]["url"].startswith("https://")
 
 
+def test_parse_intent_does_not_misfire_on_location_substring():
+    """Regression (#48, production incident): "why is the bali bachelor
+    party whiteboard full of stubs, when i ask you to add the location can
+    you provide some details from the web and like google maps etc" -- a
+    conversational question/feature request, not a command -- got
+    misclassified as an actionable add_card request. Root cause: add_match's
+    (?:to|on) lacked word boundaries, so it matched the "on" inside
+    "locati|on|" as if the user had written "add X on Y board", producing
+    content="the locati" and board_ref="can you provide...". That garbage
+    board_ref never resolves, so the reply becomes the wrong "Which board?"
+    disambiguation instead of a real answer."""
+    from orchestrator.router import WhiteboardPlugin
+
+    plugin = WhiteboardPlugin()
+    intent = plugin._parse_intent(
+        "why is the bali bachelor party whiteboard full of stubs, when i ask "
+        "you to add the location can you provide some details from the web "
+        "and like google maps etc"
+    )
+    assert intent.get("action") is None, f"should not match any fast action, got: {intent}"
+
+    # Legitimate add/pin commands (including ones containing "location" as a
+    # real word) must still match correctly.
+    assert plugin._parse_intent("add lunch to my Bali board") == {
+        "action": "add_card",
+        "kind": "note",
+        "content": "lunch",
+        "board_ref": "Bali",
+    }
+    assert plugin._parse_intent("add the hotel location to my Bali board")["action"] == "add_card"
+    assert plugin._parse_intent("pin this to my Tokyo board")["action"] == "pin"
+
+
+@pytest.mark.asyncio
+async def test_whiteboard_feedback_message_reaches_planning_intake_not_which_board(monkeypatch):
+    """End-to-end version of the same regression: the exact reported message
+    must flow through to _planning_intake() (the real conversational/deep
+    path) rather than short-circuiting into the "Which board?" fallback."""
+    from capabilities.whiteboard import planner as wb_planner
+    from orchestrator.router import WhiteboardPlugin
+    from orchestrator.state import AssistantState
+    from langchain_core.messages import HumanMessage
+
+    async def fake_comprehend(text, board_context=None):
+        return {"action": "none"}
+
+    monkeypatch.setattr(wb_planner, "comprehend_request", fake_comprehend)
+
+    plugin = WhiteboardPlugin()
+    state = AssistantState(
+        messages=[HumanMessage(content=(
+            "why is the bali bachelor party whiteboard full of stubs, when i ask "
+            "you to add the location can you provide some details from the web "
+            "and like google maps etc"
+        ))],
+        user_id=7801,
+    )
+    res = await plugin.execute(state)
+    body = res.message.content
+
+    assert "Which board?" not in body
+    assert "I can run your planning boards from chat" in body
+
+
 @pytest.mark.asyncio
 async def test_planning_intake_fails_fast_instead_of_hanging_past_webhook_timeout(monkeypatch):
     """Regression: a real production incident where "bring up the upcoming


### PR DESCRIPTION
Fixes #48.

## Root cause

Production repro: "why is the bali bachelor party whiteboard full of stubs, when i ask you to add the location can you provide some details from the web and like google maps etc" — a conversational question/feature request, not a command — got misclassified as an actionable `add_card` request and replied with the wrong "🤔 Which board?" disambiguation instead of a real answer.

`WhiteboardPlugin._parse_intent()`'s `add_match` regex used bare `(?:to|on)` with no word boundary, so it could match "on" (or "to") as a substring inside an unrelated word. Here it matched the "on" inside "locati|on|", splitting the message into `content="the locati"` and `board_ref="can you provide some details from the web and like google maps etc"` — a garbage board_ref that never resolves to a real board, producing the observed reply exactly. `pin_match` already guarded this correctly with `\b(?:to|on)\b`; `add_match` didn't.

Verified this same conversation's earlier "put Reload wellness canggu as one of the location" turn was **not** this bug — it contains no "add" at all, so it correctly fell through to `_planning_intake()` (confirmed against Railway logs: the resulting "🎨 Updated..." reply matches `_planning_intake()`'s real, tool-backed `augment_board` reply format exactly, contradicting the separate audit report on #47 that claimed no tool was invoked — leaving a comment there explaining that separately).

## Fix

Add `\b` word boundaries around `(?:to|on)` in `add_match`, matching `pin_match`'s existing pattern.

## Testing

- `test_parse_intent_does_not_misfire_on_location_substring`: the exact repro text returns `action=None`, while legitimate commands like "add lunch to my Bali board" and "add the hotel location to my Bali board" still match correctly.
- `test_whiteboard_feedback_message_reaches_planning_intake_not_which_board`: end-to-end — the same message now reaches `_planning_intake()` instead of the wrong "Which board?" fallback.
- Verified via `git stash` that both fail against pre-fix code with the exact garbage `board_ref` seen in production, and pass against the fix.
- Full suite: `uv run pytest -q` → 229 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_