### PR TITLE
feat(orchestrator): let the bot troubleshoot itself when the user asks why something happened

### DIFF
--- a/orchestrator/plan_router.py
+++ b/orchestrator/plan_router.py
@@ -13,7 +13,14 @@ from langgraph.graph import END
 from capabilities.retrieval import RetrievalResult
 from core.config import settings
 from orchestrator.planner import Decision, decision_to_dict, deterministic_plan
+from orchestrator.self_diagnostics import looks_like_self_diagnostic_question
 from orchestrator.state import AssistantState
+
+# Bounded like every other LLM-backed step in this pipeline (see core/llm.py's
+# LLM_REQUEST_TIMEOUT_SECONDS and orchestrator/router.py's
+# PLANNING_INTAKE_TIMEOUT_SECONDS) -- a slow self-diagnosis must fall through
+# to normal routing, not silently eat the webhook's own budget.
+SELF_DIAGNOSTIC_TIMEOUT_SECONDS = 20.0
 
 
 def _user_text(state: AssistantState) -> tuple[str, bool]:
@@ -118,6 +125,34 @@ async def plan_dispatch(state: AssistantState) -> Command[str]:
                 ],
             )
         )
+
+    # Regression-class fix: "why is this happening" / "this is broken" style
+    # meta-questions about the bot's own behavior kept getting misrouted into
+    # a random capability's own disambiguation flow (e.g. #48's "🤔 Which
+    # board?" misfire) instead of actually being answered. Intercept them
+    # deterministically, before the planner ever sees the text, and answer
+    # from the bot's own last routing decision + live integration health.
+    # Falls through to normal routing when there's nothing yet to explain
+    # (fresh conversation) or the explanation itself fails/times out.
+    if looks_like_self_diagnostic_question(text):
+        from orchestrator.self_diagnostics import explain_last_turn
+
+        try:
+            explanation = await asyncio.wait_for(
+                explain_last_turn(state), timeout=SELF_DIAGNOSTIC_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            explanation = None
+        if explanation:
+            schedule_turn_audit(explanation)
+            return Command(
+                goto=END,
+                update={
+                    "messages": [AIMessage(content=explanation)],
+                    "active_domain": state.get("active_domain"),
+                    "intent_type": "self_diagnostic",
+                },
+            )
 
     from capabilities.registry import load_registry
     from capabilities.retrieval import build_index

--- a/orchestrator/self_diagnostics.py
+++ b/orchestrator/self_diagnostics.py
@@ -1,0 +1,176 @@
+"""Self-diagnosis: when the user asks why the bot did something or why
+something isn't working, answer honestly from the bot's own last routing
+decision plus live integration health -- instead of running the question
+through normal capability routing.
+
+Routing it normally is exactly the failure mode this exists to avoid: this
+class of message ("this is broken", "is it not working?", "why is this
+happening") has repeatedly gotten misrouted into a random capability's own
+disambiguation flow (see #48's "🤔 Which board?" misfire) rather than
+actually being answered. Intercepting it deterministically, before the
+planner ever sees it, sidesteps that whole bug class for this one intent.
+
+Deliberately scoped to "self-explain + integration health": it explains the
+bot's own last turn and names real, live-checkable causes (a missing API
+key, a disconnected mailbox, a known tracked bug). It does not pull tool
+call tracebacks or raw error logs -- that's a heavier, separate feature.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+
+from orchestrator.state import AssistantState
+
+# Deliberately narrow and self-referential: these patterns target the bot's
+# OWN recent behavior/state ("why did YOU...", "is THIS broken"), not a
+# domain question that happens to contain "why" -- e.g. "why is my flight
+# not showing up" is a real email-capability question and must NOT be
+# intercepted here. When in doubt, patterns stay narrow: a missed self-
+# diagnostic question just falls through to normal routing (unchanged
+# behavior), but a false positive here hijacks the turn from a legitimate
+# capability, which is the more expensive mistake.
+_SELF_DIAGNOSTIC_PATTERNS = (
+    r"\bwhy\s+(?:did|didn'?t|does|doesn'?t|is|isn'?t|are|aren'?t|won'?t|can'?t|couldn'?t)\s+you\b",
+    r"\bwhy\s+(?:is|isn'?t|did|didn'?t)\s+(?:this|it|that)\s+(?:happen|happening|not\s+work|broken)",
+    r"\b(?:this|it|that)\s+(?:is|'s)\s+(?:broken|not\s+working|glitch\w*|bugg\w*)\b",
+    r"\bis\s+(?:this|it|something)\s+(?:broken|wrong|not\s+working)\b",
+    r"\bwhat(?:'?s| is| went)\s+(?:wrong|broken|going on)\b",
+    r"\b(?:can you )?(?:debug|troubleshoot)\s+(?:this|that|it)\b",
+)
+_SELF_DIAGNOSTIC_RE = re.compile("|".join(_SELF_DIAGNOSTIC_PATTERNS), re.IGNORECASE)
+
+
+def looks_like_self_diagnostic_question(text: str) -> bool:
+    """True when `text` reads as a meta-question about the bot's own
+    recent behavior/state, rather than an ordinary domain request."""
+    return bool(_SELF_DIAGNOSTIC_RE.search(text or ""))
+
+
+async def check_integration_health(user_id: int) -> dict[str, Any]:
+    """Lightweight, presence-only health snapshot: what's configured and
+    connected right now. Not a deep live probe -- no outbound call to
+    verify a token still actually works, just whether one is on file."""
+    from core.config import settings
+    from capabilities.email.tools import get_user_gmail_token, get_user_outlook_token
+
+    gmail_token: Optional[str] = None
+    outlook_token: Optional[str] = None
+    try:
+        gmail_token = await get_user_gmail_token(user_id)
+    except Exception:  # noqa: BLE001 - health check must never itself fail the turn
+        pass
+    try:
+        outlook_token = await get_user_outlook_token(user_id)
+    except Exception:  # noqa: BLE001
+        pass
+
+    return {
+        "llm_provider_configured": settings.has_llm_key,
+        "web_search_configured": bool(
+            settings.tavily_api_key and not settings.tavily_api_key.startswith("your_")
+        ),
+        "maps_configured": bool(settings.google_maps_api_key),
+        "transit_live_data_configured": bool(settings.lta_account_key),
+        "gmail_connected": bool(gmail_token),
+        "outlook_connected": bool(outlook_token),
+    }
+
+
+async def recent_known_issues(user_id: int, limit: int = 3) -> list[dict[str, Any]]:
+    """Open, already-tracked production bugs for this user -- lets the bot
+    say "yeah, that's a known issue, already being looked at" instead of
+    re-diagnosing something the audit pipeline already caught and filed."""
+    from sqlmodel import select
+    from core.db import async_session_factory
+    from core.models import ProductionBugLog
+
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(ProductionBugLog)
+            .where(ProductionBugLog.user_id == user_id, ProductionBugLog.status == "open")
+            .order_by(ProductionBugLog.updated_at.desc())
+            .limit(limit)
+        )
+        rows = result.scalars().all()
+    return [
+        {
+            "title": row.title,
+            "subsystem": row.subsystem,
+            "severity": row.severity,
+            "github_issue_url": row.github_issue_url,
+        }
+        for row in rows
+    ]
+
+
+_SYSTEM_PROMPT = (
+    "You are Nexus Prime, debugging your own recent behavior for the user who "
+    "just asked why something happened or isn't working. You are given three "
+    "sources of ground truth: (1) the recent conversation, (2) your own internal "
+    "routing decision for the last turn (which capability you picked, your "
+    "confidence, whether you had to re-plan, your internal rationale), and (3) "
+    "the current live status of your own integrations/API keys and any known "
+    "tracked bugs already filed for this user.\n\n"
+    "Explain honestly and simply what happened and why, in plain conversational "
+    "language -- never mention internal field names, code, file paths, or raw "
+    "JSON. If a real, nameable cause is present in the data below (a missing API "
+    "key, a disconnected mailbox, a known open bug), say so plainly and suggest "
+    "one concrete next step. If nothing below explains it, say you're not sure "
+    "and offer to have the user try again or rephrase -- never invent a cause "
+    "that isn't backed by the data given."
+)
+
+
+async def explain_last_turn(state: AssistantState) -> Optional[str]:
+    """Compose an honest, plain-language explanation of the bot's own last
+    turn plus current integration health. Returns None when there's nothing
+    to introspect yet (e.g. the very first message in a conversation) or the
+    LLM call fails, so the caller can fall back to normal routing."""
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    from core.llm import ThinkingLevel, extract_llm_text, get_agent_llm
+
+    user_id = state.get("user_id", 0)
+    last_decision = state.get("last_decision")
+    messages = state.get("messages", [])
+
+    # Recent turns for context, excluding the "why" question itself (the
+    # newest message) -- a handful of prior turns is enough to ground the
+    # explanation without ballooning the prompt.
+    tail = messages[-7:-1] if len(messages) > 1 else []
+    transcript_lines = []
+    for m in tail:
+        if isinstance(m, HumanMessage):
+            transcript_lines.append(f"User: {str(m.content)[:300]}")
+        elif isinstance(m, AIMessage):
+            transcript_lines.append(f"Assistant: {str(m.content)[:300]}")
+
+    if not last_decision and not transcript_lines:
+        return None
+
+    health = await check_integration_health(user_id)
+    known_issues = await recent_known_issues(user_id)
+
+    context_parts = [
+        "Recent conversation:\n" + ("\n".join(transcript_lines) or "(none)"),
+        "Your last routing decision:\n"
+        + (json.dumps(last_decision, ensure_ascii=False) if last_decision else "(none recorded)"),
+        "Your integration health right now:\n" + json.dumps(health, ensure_ascii=False),
+        "Known open bugs already tracked for this user:\n"
+        + (json.dumps(known_issues, ensure_ascii=False) if known_issues else "(none)"),
+    ]
+
+    try:
+        llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.3)
+        ai_message = await llm.ainvoke(
+            [
+                SystemMessage(content=_SYSTEM_PROMPT),
+                HumanMessage(content="\n\n".join(context_parts)),
+            ]
+        )
+    except Exception as exc:  # noqa: BLE001 - never let self-diagnosis itself break the turn
+        print(f"[SELF_DIAGNOSTIC] explain_last_turn failed: {exc}")
+        return None
+
+    return extract_llm_text(getattr(ai_message, "content", "")).strip() or None

--- a/tests/test_self_diagnostics.py
+++ b/tests/test_self_diagnostics.py
@@ -1,0 +1,249 @@
+"""Self-diagnosis: "why is this happening"/"this is broken" style meta-
+questions about the bot's own behavior get intercepted before normal
+capability routing and answered from the bot's own last routing decision
+plus live integration health, instead of being misrouted into a random
+capability's own disambiguation flow (the exact failure class #48 fixed for
+one specific capability)."""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from core.db import async_session_factory, init_db
+from core.models import ProductionBugLog
+from orchestrator.self_diagnostics import (
+    check_integration_health,
+    explain_last_turn,
+    looks_like_self_diagnostic_question,
+    recent_known_issues,
+)
+
+
+@pytest.fixture(autouse=True)
+async def ensure_db():
+    await init_db()
+
+
+# --- looks_like_self_diagnostic_question ------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "this is broken",
+    "is it not working?",
+    "why is this happening",
+    "why did you do that",
+    "why can't you do this",
+    "what's wrong",
+    "what went wrong",
+    "can you troubleshoot this",
+    "is something broken",
+])
+def test_matches_real_self_diagnostic_messages(text):
+    assert looks_like_self_diagnostic_question(text) is True
+
+
+@pytest.mark.parametrize("text", [
+    "why is my flight not showing up",
+    "what's happening this weekend in Bali",
+    "add the hotel location to my board",
+    "why did the bus arrive late",
+    "spent $15 on lunch",
+    "",
+])
+def test_does_not_misfire_on_domain_questions(text):
+    assert looks_like_self_diagnostic_question(text) is False
+
+
+# --- check_integration_health / recent_known_issues -------------------------
+
+@pytest.mark.asyncio
+async def test_check_integration_health_reports_configured_state(monkeypatch):
+    from core.config import settings
+    import capabilities.email.tools as email_tools
+
+    monkeypatch.setattr(settings, "tavily_api_key", "real-tavily-key")
+    monkeypatch.setattr(settings, "google_maps_api_key", "")
+    monkeypatch.setattr(settings, "lta_account_key", None)
+    monkeypatch.setattr(email_tools, "get_user_gmail_token", lambda user_id: _async_return("gmail-token"))
+    monkeypatch.setattr(email_tools, "get_user_outlook_token", lambda user_id: _async_return(None))
+
+    health = await check_integration_health(user_id=8801)
+
+    assert health["web_search_configured"] is True
+    assert health["maps_configured"] is False
+    assert health["transit_live_data_configured"] is False
+    assert health["gmail_connected"] is True
+    assert health["outlook_connected"] is False
+
+
+async def _async_return(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_recent_known_issues_returns_only_open_bugs_for_this_user():
+    async with async_session_factory() as session:
+        session.add(ProductionBugLog(
+            fingerprint="fp_open_8802",
+            title="Email search silently drops Outlook results",
+            subsystem="email",
+            user_id=8802,
+            status="open",
+            github_issue_url="https://github.com/benjamin-wo/nexus-prime/issues/999",
+        ))
+        session.add(ProductionBugLog(
+            fingerprint="fp_resolved_8802",
+            title="Resolved bug, should not show up",
+            subsystem="email",
+            user_id=8802,
+            status="resolved",
+        ))
+        session.add(ProductionBugLog(
+            fingerprint="fp_other_user",
+            title="Someone else's bug",
+            subsystem="routes",
+            user_id=9999,
+            status="open",
+        ))
+        await session.commit()
+
+    issues = await recent_known_issues(user_id=8802)
+
+    assert len(issues) == 1
+    assert issues[0]["title"] == "Email search silently drops Outlook results"
+    assert issues[0]["github_issue_url"] == "https://github.com/benjamin-wo/nexus-prime/issues/999"
+
+
+# --- explain_last_turn -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_explain_last_turn_returns_none_with_no_history():
+    state = {"user_id": 8803, "last_decision": None, "messages": []}
+    assert await explain_last_turn(state) is None
+
+
+@pytest.mark.asyncio
+async def test_explain_last_turn_grounds_reply_in_last_decision_and_health(monkeypatch):
+    import orchestrator.self_diagnostics as sd
+
+    monkeypatch.setattr(sd, "check_integration_health", lambda user_id: _async_return({
+        "gmail_connected": False,
+        "outlook_connected": False,
+    }))
+    monkeypatch.setattr(sd, "recent_known_issues", lambda user_id, limit=3: _async_return([]))
+
+    captured = {}
+
+    class _FakeLLM:
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return AIMessage(content="Your email isn't connected yet, that's why the search came up empty.")
+
+    monkeypatch.setattr("core.llm.get_agent_llm", lambda *a, **k: _FakeLLM())
+
+    state = {
+        "user_id": 8804,
+        "last_decision": {
+            "capabilities": [{"id": "email", "reason": "user asked about their inbox", "confidence": 0.9}],
+            "ordering": ["email"],
+            "source": "llm",
+        },
+        "messages": [
+            HumanMessage(content="check my email for flight bookings"),
+            AIMessage(content="I couldn't find anything -- your mailbox isn't connected yet."),
+            HumanMessage(content="why is this happening"),
+        ],
+    }
+    result = await explain_last_turn(state)
+
+    assert result == "Your email isn't connected yet, that's why the search came up empty."
+    prompt_text = str(captured["messages"])
+    assert "email" in prompt_text
+    assert "gmail_connected" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_explain_last_turn_returns_none_when_llm_fails(monkeypatch):
+    import orchestrator.self_diagnostics as sd
+
+    monkeypatch.setattr(sd, "check_integration_health", lambda user_id: _async_return({}))
+    monkeypatch.setattr(sd, "recent_known_issues", lambda user_id, limit=3: _async_return([]))
+
+    class _BrokenLLM:
+        async def ainvoke(self, messages):
+            raise RuntimeError("provider down")
+
+    monkeypatch.setattr("core.llm.get_agent_llm", lambda *a, **k: _BrokenLLM())
+
+    state = {
+        "user_id": 8805,
+        "last_decision": {"ordering": ["general"]},
+        "messages": [HumanMessage(content="this is broken")],
+    }
+    assert await explain_last_turn(state) is None
+
+
+# --- end-to-end via plan_dispatch --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_plan_dispatch_intercepts_self_diagnostic_question(monkeypatch):
+    from unittest.mock import AsyncMock, patch
+
+    from orchestrator.plan_router import plan_dispatch
+
+    def _boom(*a, **k):
+        raise AssertionError("normal capability planning must not run for a self-diagnostic question")
+
+    monkeypatch.setattr(
+        "orchestrator.self_diagnostics.explain_last_turn",
+        AsyncMock(return_value="I misread your last message, sorry about that -- here's what actually happened."),
+    )
+
+    state = {
+        "user_id": 8806,
+        "active_domain": "email",
+        "last_decision": {"ordering": ["email"]},
+        "messages": [HumanMessage(content="why is this happening")],
+    }
+    with patch("orchestrator.planner.plan_with_llm", side_effect=_boom), \
+            patch("orchestrator.planner.deterministic_plan", side_effect=_boom):
+        command = await plan_dispatch(state)
+
+    assert command.update["messages"][-1].content == (
+        "I misread your last message, sorry about that -- here's what actually happened."
+    )
+    assert command.update["intent_type"] == "self_diagnostic"
+    assert command.update["active_domain"] == "email"
+
+
+@pytest.mark.asyncio
+async def test_plan_dispatch_falls_through_to_normal_routing_when_nothing_to_explain(monkeypatch):
+    from unittest.mock import AsyncMock, patch
+
+    from orchestrator.plan_router import plan_dispatch
+    from orchestrator.planner import Decision, CapabilitySelection
+    from orchestrator.router import PluginOutput
+
+    monkeypatch.setattr(
+        "orchestrator.self_diagnostics.explain_last_turn",
+        AsyncMock(return_value=None),
+    )
+
+    fake_plugin = AsyncMock()
+    fake_plugin.execute.return_value = PluginOutput(message=AIMessage(content="general reply"))
+    decision = Decision(
+        capabilities=[CapabilitySelection(id="general", reason="fallback", confidence=0.6)],
+        ordering=["general"],
+        confidence=0.6,
+        source="test",
+    )
+
+    state = {
+        "user_id": 8807,
+        "active_domain": None,
+        "last_decision": None,
+        "messages": [HumanMessage(content="is something broken")],
+    }
+    with patch("orchestrator.router.CAPABILITY_REGISTRY", {"general": fake_plugin}), \
+            patch("orchestrator.planner.plan_with_llm", new=AsyncMock(return_value=decision)):
+        command = await plan_dispatch(state)
+
+    fake_plugin.execute.assert_awaited_once()
+    assert command.update["messages"][-1].content == "general reply"


### PR DESCRIPTION
Requested directly by the owner: the orchestrator should be able to answer "why is this happening" / "this is broken" style questions about its own behavior, instead of either staying silent or — as happened repeatedly this session (#48) — misrouting the question into some capability's own disambiguation flow.

## Scope

Locked with the owner via two quick questions: **self-explain reasoning** (what the bot understood and did on its last turn) **plus live integration health** (named, real causes like a missing API key or disconnected mailbox), triggered by **freeform detection** rather than a dedicated command.

## What's new

- `orchestrator/self_diagnostics.py`:
  - `looks_like_self_diagnostic_question()` — a deliberately narrow, self-referential regex (targets "why did YOU...", "is THIS broken", not domain questions that happen to contain "why" — e.g. "why is my flight not showing up" must stay routed to email). A missed self-diagnostic question just falls through to normal routing (no behavior change); a false positive here would hijack a legitimate capability turn, which is the more expensive mistake, so the pattern list stays tight.
  - `check_integration_health()` — presence-only snapshot of what's configured/connected right now (LLM provider, Tavily, Google Maps/LTA, Gmail/Outlook) — no outbound calls to verify a token still works, just what's on file.
  - `recent_known_issues()` — open `ProductionBugLog` rows for this user, so the bot can say "yeah, that's a known issue already being looked at" instead of re-diagnosing something the audit pipeline already caught and filed to GitHub.
  - `explain_last_turn()` — grounds one LLM call in the last few conversation turns, the bot's own last routing decision (already persisted in state as `last_decision` — no new tracing infra needed), the health snapshot, and known issues. Explicitly instructed to never invent a cause not backed by that data, and to never leak internal field names/code/JSON to the user. Returns `None` (falls through to normal routing) when there's nothing yet to explain or the LLM call itself fails.

- `orchestrator/plan_router.py`: intercepts before all other routing (fast_path, deterministic_plan, plan_with_llm) so a self-diagnostic question can never be misrouted into a capability's own parsing — the exact bug class #48 fixed for one specific capability, closed here for the general case. Bounded by `SELF_DIAGNOSTIC_TIMEOUT_SECONDS=20s` (same "bound every layer" pattern as `PLANNING_INTAKE_TIMEOUT_SECONDS`/`LLM_REQUEST_TIMEOUT_SECONDS`) so a slow diagnosis falls through to normal routing rather than eating the webhook's own budget.

## Testing

- `tests/test_self_diagnostics.py`, 22 cases: detector true/false positives (including the exact "why is my flight not showing up" style domain question that must **not** be intercepted), integration-health reporting, known-issues DB scoping (only this user's open bugs), `explain_last_turn` grounding + graceful `None` on empty history/LLM failure, and two full `plan_dispatch()` end-to-end cases — a self-diagnostic question short-circuits before `plan_with_llm`/`deterministic_plan` ever run (asserted via a hard failure if they're called), and a message that also matches the pattern but has nothing to explain yet falls through to normal capability routing unchanged.
- Full suite: `uv run pytest -q` → 251 passed, 8 failed (pre-existing baseline failures unrelated to this change: `test_code_sandbox.py` probes 1-5, `test_planner.py::test_llm_planner_used_when_key_present`, `test_recipes.py::test_spend_autopsy_uses_sandbox`, `test_verify.py::test_verify_with_llm_parses_json`).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_