### PR TITLE
Thread recent conversation history into domain plugins (#35)

### DIFF
--- a/capabilities/expenses/tools.py
+++ b/capabilities/expenses/tools.py
@@ -585,10 +585,16 @@ def _resolve_email_merchant(
 
 
 @tool
-async def extract_expense_from_text(user_text: str) -> Dict[str, Any]:
+async def extract_expense_from_text(user_text: str, recent_context: str = "") -> Dict[str, Any]:
     """
     Extract structured expense fields from a natural-language message.
     Returns amount, currency, merchant, category, date_iso, confidence, needs_clarification.
+
+    recent_context (#35): the last few conversation turns, used ONLY to
+    resolve an explicit correction/follow-up on the CURRENT message (e.g.
+    "actually make that $20" right after "logged $15 for lunch") -- this is
+    a money-writing path, so it must never be used to invent a transaction
+    the current message doesn't itself describe. See rule 6 below.
     """
     messages = [
         SystemMessage(
@@ -602,10 +608,21 @@ async def extract_expense_from_text(user_text: str) -> Dict[str, Any]:
                 '4. date_iso: the transaction date must be within 14 days of the email\'s own timestamp or the current date. NEVER invent a year or copy a year from account numbers, membership dates (e.g. "member since 2022") or reference IDs. If the message shows only day/month (e.g. "22 Aug"), use the current year; if no transaction date is shown at all, return "".\n'
                 "5. Reply with ONLY a JSON object:\n"
                 '{"amount": number|null, "currency": string, "merchant": string, "category": string, "date_iso": string, "confidence": number, "needs_clarification": boolean}\n'
-                "Default currency: SGD for Singapore."
+                "Default currency: SGD for Singapore.\n"
+                "6. A 'Recent conversation' block, if present below, is ONLY for resolving an "
+                "explicit correction to the CURRENT message (e.g. 'actually make that $20' "
+                "referring back to an amount just discussed). NEVER use it to extract an "
+                "expense the current message does not itself describe -- if the current "
+                "message alone has no genuine paid expense, return {\"amount\": null} "
+                "regardless of what the recent conversation contains."
             )
         ),
-        HumanMessage(content=user_text[:2000]),
+        HumanMessage(
+            content=(
+                (f"Recent conversation:\n{recent_context}\n\n---\n\n" if recent_context else "")
+                + user_text[:2000]
+            )
+        ),
     ]
 
     try:

--- a/capabilities/recipes/tools.py
+++ b/capabilities/recipes/tools.py
@@ -13,10 +13,17 @@ from core.models import GroceryItem
 
 
 @tool
-async def parse_recipe_and_extract_ingredients(recipe_text_or_url: str) -> Dict[str, Any]:
+async def parse_recipe_and_extract_ingredients(
+    recipe_text_or_url: str, recent_context: str = ""
+) -> Dict[str, Any]:
     """
     Extract a recipe title and structured ingredient list from recipe text.
     Each ingredient has name, quantity, and category.
+
+    recent_context (#35): the last few conversation turns, so a follow-up
+    correction ("actually make it 2 eggs, not 3") can be resolved against the
+    recipe pasted a turn earlier instead of being read as a fresh, incomplete
+    recipe on its own.
     """
     canned_fallback = {
         "title": "Extracted Recipe",
@@ -39,10 +46,19 @@ async def parse_recipe_and_extract_ingredients(recipe_text_or_url: str) -> Dict[
                         'a JSON object: {"title": string, "ingredients": [{"name": string, '
                         '"quantity": string, "category": string}]}. Categories: Produce, Meat, Dairy, '
                         "Pantry, Pasta, Bakery, Frozen, Spices, Other. If no recipe is present, return "
-                        '{"title": "", "ingredients": []}.'
+                        '{"title": "", "ingredients": []}. If recent conversation is provided, use it '
+                        "ONLY to resolve a correction or continuation of a recipe already discussed "
+                        "(e.g. 'actually use 2 eggs') — the current message is always the recipe to "
+                        "extract; never pull in ingredients from an unrelated earlier recipe."
                     )
                 ),
-                HumanMessage(content=recipe_text_or_url[:4000]),
+                HumanMessage(
+                    content=(
+                        f"Recent conversation:\n{recent_context}\n\n---\n\n{recipe_text_or_url[:4000]}"
+                        if recent_context
+                        else recipe_text_or_url[:4000]
+                    )
+                ),
             ]
         )
         raw = str(getattr(ai_message, "content", "") or "").strip()

--- a/capabilities/reminders/tools.py
+++ b/capabilities/reminders/tools.py
@@ -211,12 +211,17 @@ def _regex_parse_reminder(text: str, default_tz: str = "Asia/Singapore") -> Opti
 
 
 @tool
-async def parse_reminder_request(user_text: str) -> Dict[str, Any]:
+async def parse_reminder_request(user_text: str, recent_context: str = "") -> Dict[str, Any]:
     """
     Parse a natural-language reminder request into an action, schedule, and message.
     Returns {"action": "create"|"list"|"delete", "reminder_type": "once"|"recurring",
              "delay_seconds": number|null, "message": string, "cron": string|null,
              "timezone": string, "job_id": number|null}.
+
+    recent_context (#35): the last few conversation turns, so a follow-up
+    correction ("actually make that every day instead") can be resolved
+    against the reminder just discussed. Only reaches the LLM path — the
+    deterministic regex fast path above is untouched.
     """
     # 1. Deterministic fast path
     regex_res = _regex_parse_reminder(user_text)
@@ -254,10 +259,20 @@ async def parse_reminder_request(user_text: str) -> Dict[str, Any]:
                         "   - NEVER invent a recurring schedule for a one-time request like 'remind me at 10am to text X' — that must be 'once'\n"
                         "3. LISTING: action = 'list'\n"
                         "4. DELETING (e.g. 'delete reminder 3'): action = 'delete', job_id = 3\n"
-                        "Default timezone: Asia/Singapore."
+                        "Default timezone: Asia/Singapore.\n"
+                        "If recent conversation is provided, use it ONLY to resolve a correction or "
+                        "continuation of a reminder already being set up (e.g. 'actually every day') — "
+                        "the current message is always the request to parse; never invent a reminder "
+                        "from unrelated earlier conversation."
                     )
                 ),
-                HumanMessage(content=user_text[:2000]),
+                HumanMessage(
+                    content=(
+                        f"Recent conversation:\n{recent_context}\n\n---\n\n{user_text[:2000]}"
+                        if recent_context
+                        else user_text[:2000]
+                    )
+                ),
             ]
         )
         raw = str(getattr(ai_message, "content", "") or "").strip()

--- a/capabilities/routes/tools.py
+++ b/capabilities/routes/tools.py
@@ -85,11 +85,19 @@ async def plan_route(origin: str, destination: str, mode: str = "transit") -> Di
 
 
 @tool
-async def extract_route_request(user_text: str) -> Dict[str, Any]:
+async def extract_route_request(user_text: str, recent_context: str = "") -> Dict[str, Any]:
     """
     Extract origin, destination, and travel mode from a natural-language route request.
     Returns {"origin", "destination", "mode"} where mode is one of
     transit/driving/walking/bicycling.
+
+    recent_context (#35): the last few conversation turns, so a correction
+    like "actually from Bugis instead" can be resolved against the origin
+    named a turn earlier. This is purely additive grounding for the LLM
+    extraction prompt — it does NOT replace RoutePlugin's own last_route /
+    is_bare_place_fragment carry-over logic (router.py), which stays the
+    primary mechanism for continuing a route across turns. Only reaches the
+    LLM path; the regex fallback below is untouched.
     """
     def _regex_route(text: str) -> Dict[str, Any]:
         mode = "transit"
@@ -120,10 +128,21 @@ async def extract_route_request(user_text: str) -> Dict[str, Any]:
                     content=(
                         "Extract a route request from the user's text. Reply with ONLY a JSON object "
                         '{"origin": string, "destination": string, "mode": "transit"|"driving"|"walking"|"bicycling"}. '
-                        "If a place is missing, use null for that field. Default mode: transit."
+                        "If a place is missing, use null for that field. Default mode: transit. "
+                        "If recent conversation is provided, use it ONLY to resolve a correction to a "
+                        "place already named in this exchange (e.g. 'actually from Bugis instead') — "
+                        "never invent an origin or destination that isn't referenced in the current "
+                        "message itself; when in doubt, leave that field null and let the fallback "
+                        "carry-over logic handle it."
                     )
                 ),
-                HumanMessage(content=user_text),
+                HumanMessage(
+                    content=(
+                        f"Recent conversation:\n{recent_context}\n\n---\n\n{user_text}"
+                        if recent_context
+                        else user_text
+                    )
+                ),
             ]
         )
         raw = str(getattr(ai_message, "content", "") or "").strip()

--- a/capabilities/whiteboard/planner.py
+++ b/capabilities/whiteboard/planner.py
@@ -119,8 +119,17 @@ def validate_brief(raw: Any) -> Optional[Dict[str, Any]]:
 async def comprehend_request(
     text: str,
     board_context: Optional[Dict[str, Any]] = None,
+    recent_context: str = "",
 ) -> Optional[Dict[str, Any]]:
-    """Run the deep-reasoning comprehension pass over a freeform planning request."""
+    """Run the deep-reasoning comprehension pass over a freeform planning request.
+
+    recent_context (#35): the last few conversation turns, for resolving a
+    reactive follow-up ("no budget but thinking of some fitness club Friday")
+    against what was just discussed -- planning is inherently multi-turn, and
+    this plugin previously only ever saw the single latest message. Purely
+    additional grounding for the LLM pass; board_context and the deterministic
+    entity-materialization pipeline below are unaffected.
+    """
     if not settings.has_llm_key:
         return _heuristic_brief(text)
 
@@ -128,6 +137,12 @@ async def comprehend_request(
     from core.llm import ThinkingLevel, get_agent_llm
 
     context_lines = []
+    if recent_context:
+        context_lines.append(
+            "Recent conversation, for resolving references like 'that one too' or "
+            "a reactive follow-up -- the request below the --- separator is the "
+            f"user's CURRENT message and takes priority:\n{recent_context}"
+        )
     if board_context:
         if board_context.get("explicit_match"):
             context_lines.append(

--- a/orchestrator/checkpointer.py
+++ b/orchestrator/checkpointer.py
@@ -1,5 +1,5 @@
 from typing import List, Tuple
-from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langgraph.checkpoint.memory import MemorySaver
 from core.config import settings
 
@@ -96,3 +96,31 @@ def prune_and_summarize_messages(
     summary_str = "Prior Conversation Summary:\n" + "\n".join(summary_lines[:15])
     system_note = SystemMessage(content=f"[SYSTEM: {summary_str}]")
     return [system_note] + recent_messages, summary_str
+
+
+def recent_turns(messages: List[BaseMessage], n: int = 3, exclude_last: bool = True) -> str:
+    """Compact "User: ...\\nAssistant: ..." formatting of the last `n` human/AI
+    turn pairs, for threading into a domain plugin's own LLM extraction call
+    as follow-up context (#35) -- without changing what triggers that call in
+    the first place. Every plugin's deterministic fast-path/regex checks keep
+    operating on the single latest message exactly as before; this is purely
+    additional context for the LLM fallback path, so a reactive follow-up
+    ("make that $20 instead", "and that one too") can be resolved against
+    what was actually just discussed instead of landing as an isolated,
+    context-free request.
+
+    Excludes the current/latest message by default, since callers already
+    extract that separately as their primary input -- passing it again here
+    would just duplicate it in the prompt. Returns "" for an empty/single-
+    message history, so callers can safely omit an empty context block.
+    """
+    tail = messages[:-1] if exclude_last and messages else list(messages)
+    tail = tail[-(n * 2):]
+    lines = []
+    for m in tail:
+        if isinstance(m, HumanMessage):
+            content = m.content if isinstance(m.content, str) else str(m.content)
+            lines.append(f"User: {content[:300]}")
+        elif isinstance(m, AIMessage):
+            lines.append(f"Assistant: {str(m.content)[:300]}")
+    return "\n".join(lines)

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -201,12 +201,18 @@ class EmailPlugin:
         # literal "latest email" list, so latest is the DEFAULT for any email
         # request without an explicit financial intent; the keyword sweep runs
         # only for receipt/bill/expense/bank asks.
+        from orchestrator.checkpointer import recent_turns
+
+        recent_context = recent_turns(messages)
+
         if is_latest_email_request(last_text) or not is_financial_email_request(last_text):
             latest_results = await search_email_messages.ainvoke(
                 {"user_id": user_id, "latest": True, "provider": requested_provider_scope}
             )
             reply = AIMessage(
-                content=await self._summarize_email_results(latest_results, latest=True, user_question=last_text)
+                content=await self._summarize_email_results(
+                    latest_results, latest=True, user_question=last_text, recent_context=recent_context
+                )
             )
             return PluginOutput(
                 message=reply,
@@ -250,15 +256,27 @@ class EmailPlugin:
                 state_update={"active_domain": self.name},
             )
 
-        reply = AIMessage(content=await self._summarize_email_results(results, user_question=last_text))
+        reply = AIMessage(
+            content=await self._summarize_email_results(
+                results, user_question=last_text, recent_context=recent_context
+            )
+        )
         return PluginOutput(message=reply, state_update={"active_domain": self.name})
 
     @staticmethod
     async def _summarize_email_results(
-        results: List[Dict[str, Any]], latest: bool = False, user_question: str = ""
+        results: List[Dict[str, Any]],
+        latest: bool = False,
+        user_question: str = "",
+        recent_context: str = "",
     ) -> str:
         """Answer the user's actual question from fetched emails, or fall back to
-        a general summary for generic asks ("what's new", "check my latest email")."""
+        a general summary for generic asks ("what's new", "check my latest email").
+
+        recent_context (#35): the last few conversation turns, so a reactive
+        follow-up ("what about the one from DBS instead?") can be resolved
+        against what was just discussed rather than landing as an isolated
+        request. Purely additional grounding; never overrides user_question."""
         if not results:
             if latest:
                 return "📬 I couldn't find any emails in your mailbox right now."
@@ -296,6 +314,14 @@ class EmailPlugin:
                     "what each message is about, and flag anything that looks like a bill, "
                     "receipt, or expense."
                 )
+            human_parts = [f"Emails:\n{emails_text}"]
+            if recent_context:
+                human_parts.insert(
+                    0,
+                    "Recent conversation, for resolving a reactive follow-up like "
+                    "'what about the one from DBS instead' -- the user's question "
+                    f"above takes priority:\n{recent_context}",
+                )
             ai_message = await llm.ainvoke(
                 [
                     SystemMessage(
@@ -309,7 +335,7 @@ class EmailPlugin:
                             "making one up. Do not mention that you are a subagent."
                         )
                     ),
-                    HumanMessage(content=f"Emails:\n{emails_text}"),
+                    HumanMessage(content="\n\n---\n\n".join(human_parts)),
                 ]
             )
             summary = str(getattr(ai_message, "content", "") or "").strip()
@@ -577,7 +603,11 @@ class ExpensePlugin:
                 state_update={"active_domain": self.name},
             )
 
-        extracted = await extract_expense_from_text.ainvoke({"user_text": last_text})
+        from orchestrator.checkpointer import recent_turns
+
+        extracted = await extract_expense_from_text.ainvoke(
+            {"user_text": last_text, "recent_context": recent_turns(messages)}
+        )
         if not extracted or not extracted.get("amount"):
             return PluginOutput(
                 message=AIMessage(
@@ -744,7 +774,11 @@ class RoutePlugin:
                 },
             )
 
-        req = await extract_route_request.ainvoke({"user_text": last_text})
+        from orchestrator.checkpointer import recent_turns
+
+        req = await extract_route_request.ainvoke(
+            {"user_text": last_text, "recent_context": recent_turns(messages)}
+        )
         origin = (req.get("origin") or "").strip()
         destination = (req.get("destination") or "").strip()
         mode = req.get("mode") or "transit"
@@ -827,8 +861,10 @@ class RecipePlugin:
         messages = state.get("messages", [])
         last_text = str(messages[-1].content) if messages else ""
 
+        from orchestrator.checkpointer import recent_turns
+
         res = await parse_recipe_and_extract_ingredients.ainvoke(
-            {"recipe_text_or_url": last_text}
+            {"recipe_text_or_url": last_text, "recent_context": recent_turns(messages)}
         )
         ingredients = res.get("ingredients") or []
         if not ingredients:
@@ -1170,7 +1206,11 @@ class ReminderPlugin:
         messages = state.get("messages", [])
         last_text = str(messages[-1].content) if messages else ""
 
-        parsed = await parse_reminder_request.ainvoke({"user_text": last_text})
+        from orchestrator.checkpointer import recent_turns
+
+        parsed = await parse_reminder_request.ainvoke(
+            {"user_text": last_text, "recent_context": recent_turns(messages)}
+        )
         action = parsed.get("action")
 
         if action == "list":
@@ -1534,7 +1574,7 @@ class WhiteboardPlugin:
         # Bounded well under the webhook's own timeout -- see PLANNING_INTAKE_TIMEOUT_SECONDS.
         try:
             planned = await asyncio.wait_for(
-                self._planning_intake(user_id, last_text),
+                self._planning_intake(user_id, last_text, messages),
                 timeout=PLANNING_INTAKE_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
@@ -1561,7 +1601,9 @@ class WhiteboardPlugin:
         )
         return PluginOutput(message=AIMessage(content=reply), state_update={"active_domain": self.name})
 
-    async def _planning_intake(self, user_id: int, last_text: str) -> Optional[str]:
+    async def _planning_intake(
+        self, user_id: int, last_text: str, messages: Optional[List[Any]] = None
+    ) -> Optional[str]:
         """Deep comprehension pass: decompose a freeform request into board cards,
         research topics, and follow-up questions. Returns None when the request
         is not planning-related (caller falls back to guidance)."""
@@ -1570,6 +1612,7 @@ class WhiteboardPlugin:
             ENTITY_SECTION_DEFAULTS,
             comprehend_request,
         )
+        from orchestrator.checkpointer import recent_turns
 
         boards = await wb.list_user_boards(user_id)
         target_board = None
@@ -1615,7 +1658,9 @@ class WhiteboardPlugin:
                 "explicit_match": explicit_match,
             }
 
-        brief = await comprehend_request(last_text, board_context)
+        brief = await comprehend_request(
+            last_text, board_context, recent_context=recent_turns(messages or [])
+        )
         if not brief or brief.get("action") == "none":
             return None
 

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
-from orchestrator.checkpointer import prune_and_summarize_messages
+from orchestrator.checkpointer import prune_and_summarize_messages, recent_turns
 
 
 def _long_conversation(fact: str, turns: int = 19) -> list:
@@ -77,3 +77,49 @@ async def test_general_plugin_carries_the_summary_into_llm_history(monkeypatch):
     history_text = "\n".join(str(getattr(m, "content", "")) for m in history)
     assert "Biscuit" in history_text
     assert output.message.content == "here's what I've got"
+
+
+# --- recent_turns (#35) -------------------------------------------------
+
+def test_recent_turns_excludes_the_current_message_by_default():
+    """The current message is the plugin's own primary input, extracted
+    separately -- including it again here would just duplicate it."""
+    messages = [
+        HumanMessage(content="spent $15 on lunch"),
+        AIMessage(content="Logged $15 for lunch."),
+        HumanMessage(content="actually make that $20"),
+    ]
+    context = recent_turns(messages)
+    assert "spent $15 on lunch" in context
+    assert "Logged $15 for lunch" in context
+    assert "actually make that $20" not in context
+
+
+def test_recent_turns_caps_at_n_pairs():
+    messages = []
+    for i in range(10):
+        messages.append(HumanMessage(content=f"user turn {i}"))
+        messages.append(AIMessage(content=f"reply {i}"))
+    messages.append(HumanMessage(content="current message"))
+
+    context = recent_turns(messages, n=2)
+    assert "user turn 9" in context
+    assert "reply 9" in context
+    assert "user turn 8" in context
+    assert "user turn 7" not in context  # older than the last 2 pairs
+
+
+def test_recent_turns_empty_for_first_message_in_conversation():
+    assert recent_turns([HumanMessage(content="hello")]) == ""
+    assert recent_turns([]) == ""
+
+
+def test_recent_turns_formats_roles_distinctly():
+    messages = [
+        HumanMessage(content="what's on my Bali board"),
+        AIMessage(content="Villa Samatha, booked."),
+        HumanMessage(content="current"),
+    ]
+    context = recent_turns(messages)
+    assert "User: what's on my Bali board" in context
+    assert "Assistant: Villa Samatha, booked." in context

--- a/tests/test_email_and_expenses.py
+++ b/tests/test_email_and_expenses.py
@@ -926,3 +926,46 @@ async def test_expense_plugin_photo_falls_back_to_caption_expense(monkeypatch):
     # _finalize_expense returns a plain string, not an AIMessage.
     assert "10.00" in str(out.message)
     assert "Parking" in str(out.message)
+
+
+@pytest.mark.asyncio
+async def test_expense_plugin_threads_recent_conversation_into_text_extraction(monkeypatch):
+    """#35: a correction like "actually make that $20" only makes sense with
+    the prior turn in view. ExpensePlugin's main text-extraction call site
+    must pass recent_turns(messages) through to extract_expense_from_text so
+    the LLM can resolve the correction instead of guessing from "actually
+    make that $20" alone."""
+    import orchestrator.router as router_module
+    from orchestrator.router import ExpensePlugin
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    captured = {}
+
+    async def fake_text_extract(**kwargs):
+        captured.update(kwargs)
+        return {
+            "amount": 20.0,
+            "currency": "USD",
+            "merchant": "Lunch",
+            "category": "Food",
+            "date_iso": "",
+            "confidence": 0.9,
+            "needs_clarification": False,
+        }
+
+    monkeypatch.setattr(router_module.extract_expense_from_text, "coroutine", fake_text_extract)
+
+    out = await ExpensePlugin().execute({
+        "messages": [
+            HumanMessage(content="spent $15 on lunch"),
+            AIMessage(content="Logged $15.00 for Lunch."),
+            HumanMessage(content="actually make that $20 instead"),
+        ],
+        "user_id": 4003,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    assert "recent_context" in captured
+    assert "spent $15 on lunch" in captured["recent_context"]
+    assert "20.00" in str(out.message)

--- a/tests/test_latency_budgets.py
+++ b/tests/test_latency_budgets.py
@@ -39,7 +39,7 @@ async def test_whiteboard_planning_intake_never_exceeds_webhook_budget(monkeypat
     SCALE = 100.0  # real: comprehend ~30s + research ~15s vs 45s webhook ceiling
     monkeypatch.setattr(router_module, "PLANNING_INTAKE_TIMEOUT_SECONDS", 35.0 / SCALE)
 
-    async def slow_comprehend(text, board_context=None):
+    async def slow_comprehend(text, board_context=None, recent_context=""):
         # Stands in for comprehend_request's own ~30s ceiling PLUS a
         # subsequent research pass's ~15s -- individually each fits its own
         # bound, but their sum (45s) exceeds PLANNING_INTAKE_TIMEOUT_SECONDS

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -255,6 +255,143 @@ async def test_email_plugin_summary_prompt_carries_the_user_question(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_email_plugin_threads_recent_conversation_into_summary_prompt(monkeypatch):
+    """Regression (#35): EmailPlugin used to read only messages[-1], so a
+    reactive follow-up ("what about the one from DBS instead") had nothing
+    to resolve against. The recent conversation must now reach the
+    summarizer's prompt alongside the current question."""
+    from unittest.mock import AsyncMock
+    from langchain_core.messages import AIMessage
+    import orchestrator.router as router_module
+    import capabilities.email.tools as email_tools
+
+    async def fake_search(**kwargs):
+        return [{"sender": "DBS <alerts@dbs.com>", "subject": "Statement ready", "date": "2026-08-24T10:00:00Z"}]
+
+    monkeypatch.setattr(router_module, "get_user_gmail_token", AsyncMock(return_value="mock_token"))
+    monkeypatch.setattr(router_module, "get_user_outlook_token", AsyncMock(return_value=None))
+    monkeypatch.setattr(email_tools.search_email_messages, "coroutine", fake_search)
+    monkeypatch.setattr(router_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    captured: dict = {}
+
+    class _CapturingLLM:
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return AIMessage(content="Here's the DBS statement email.")
+
+    monkeypatch.setattr(router_module, "get_agent_llm", lambda *a, **k: _CapturingLLM())
+
+    out = await EmailPlugin().execute({
+        "messages": [
+            HumanMessage(content="did I get anything from the bank recently?"),
+            AIMessage(content="I found a couple of bank emails — want me to check a specific one?"),
+            HumanMessage(content="what about the one from DBS instead"),
+        ],
+        "user_id": 4002,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    human_prompt = str(captured["messages"][1].content)
+    assert "did I get anything from the bank recently" in human_prompt
+    assert "I found a couple of bank emails" in human_prompt
+    assert "Here's the DBS statement email" in str(out.message.content)
+
+
+@pytest.mark.asyncio
+async def test_route_plugin_threads_recent_conversation_into_extraction(monkeypatch):
+    """Regression (#35): RoutePlugin's extract_route_request call used to
+    read only messages[-1], so a correction like "actually from Bugis
+    instead" had no prior route to resolve against. recent_turns(messages)
+    must now reach the extraction prompt -- this must NOT touch the
+    deterministic bus-arrival path (handle_bus_query/pending_bus_stops),
+    which stays untouched."""
+    import orchestrator.router as router_module
+    from orchestrator.router import RoutePlugin
+    from langchain_core.messages import AIMessage
+
+    captured: dict = {}
+
+    async def fake_extract(**kwargs):
+        captured.update(kwargs)
+        return {"origin": "Bugis", "destination": "Changi Airport", "mode": "transit"}
+
+    async def fake_journey(origin, destination):
+        return {"error": "no live feed"}
+
+    async def fake_plan_route(**kwargs):
+        return {
+            "origin": kwargs["origin"],
+            "destination": kwargs["destination"],
+            "mode": kwargs["mode"],
+            "eta_minutes": 40,
+            "distance_km": 20,
+            "steps": ["Take the MRT"],
+        }
+
+    monkeypatch.setattr(router_module.extract_route_request, "coroutine", fake_extract)
+    monkeypatch.setattr(router_module, "plan_transit_journey", fake_journey)
+    monkeypatch.setattr(router_module.plan_route, "coroutine", fake_plan_route)
+
+    out = await RoutePlugin().execute({
+        "messages": [
+            HumanMessage(content="route from Raffles Place to Changi Airport"),
+            AIMessage(content="🚇 *Raffles Place* → *Changi Airport*: ~30 min (18 km)"),
+            HumanMessage(content="actually from Bugis instead"),
+        ],
+        "user_id": 4006,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    assert "recent_context" in captured
+    assert "route from Raffles Place to Changi Airport" in captured["recent_context"]
+    assert "Bugis" in str(out.message.content)
+
+
+@pytest.mark.asyncio
+async def test_recipe_plugin_threads_recent_conversation_into_extraction(monkeypatch):
+    """Regression (#35): RecipePlugin used to read only messages[-1], so a
+    correction like "actually use 2 eggs, not 3" had no recipe to resolve
+    against. recent_turns(messages) must now reach
+    parse_recipe_and_extract_ingredients."""
+    import orchestrator.router as router_module
+    from orchestrator.router import RecipePlugin
+    from langchain_core.messages import AIMessage
+
+    captured: dict = {}
+
+    async def fake_extract(**kwargs):
+        captured.update(kwargs)
+        return {
+            "title": "Omelette",
+            "ingredients": [{"name": "Eggs", "quantity": "2", "category": "Dairy"}],
+        }
+
+    async def fake_sync(**kwargs):
+        return [1]
+
+    monkeypatch.setattr(router_module.parse_recipe_and_extract_ingredients, "coroutine", fake_extract)
+    monkeypatch.setattr(router_module.sync_to_grocery_list, "coroutine", fake_sync)
+
+    out = await RecipePlugin().execute({
+        "messages": [
+            HumanMessage(content="3 eggs, salt, butter — whisk and fry"),
+            AIMessage(content="📖 *Extracted Recipe* — added 3 items to your grocery list:"),
+            HumanMessage(content="actually make it 2 eggs, not 3"),
+        ],
+        "user_id": 4004,
+        "current_timezone": "UTC",
+        "active_domain": None,
+    })
+
+    assert "recent_context" in captured
+    assert "3 eggs, salt, butter" in captured["recent_context"]
+    assert "Omelette" in str(out.message.content)
+
+
+@pytest.mark.asyncio
 async def test_email_plugin_scopes_financial_sweep_to_named_provider(monkeypatch):
     """Regression: "look for transactions from my outlook ... log them as expenses"
     used to search ALL connected providers merged together, silently ignoring the

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -151,6 +151,50 @@ async def test_reminders_plugin_one_minute_execution():
 
 
 @pytest.mark.asyncio
+async def test_reminder_plugin_threads_recent_conversation_into_parse(monkeypatch):
+    """Regression (#35): ReminderPlugin used to read only messages[-1], so a
+    follow-up correction ("actually make it every day instead") had no
+    reminder to resolve against. recent_turns(messages) must now reach
+    parse_reminder_request's LLM path (the deterministic regex fast path is
+    untouched, since this phrasing has no relative-time expression of its
+    own to match)."""
+    import orchestrator.router as router_module
+    from orchestrator.router import ReminderPlugin
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    captured: dict = {}
+
+    async def fake_parse(**kwargs):
+        captured.update(kwargs)
+        return {
+            "action": "create",
+            "reminder_type": "recurring",
+            "delay_seconds": None,
+            "message": "drink water",
+            "cron": "0 9 * * *",
+            "timezone": "Asia/Singapore",
+            "job_id": None,
+        }
+
+    monkeypatch.setattr(router_module.parse_reminder_request, "coroutine", fake_parse)
+
+    out = await ReminderPlugin().execute({
+        "messages": [
+            HumanMessage(content="remind me to drink water at 9am"),
+            AIMessage(content="Reminder set for 9:00 AM."),
+            HumanMessage(content="actually make it every day instead"),
+        ],
+        "user_id": 4005,
+        "current_timezone": "Asia/Singapore",
+        "active_domain": None,
+    })
+
+    assert "recent_context" in captured
+    assert "remind me to drink water at 9am" in captured["recent_context"]
+    assert out.message is not None
+
+
+@pytest.mark.asyncio
 async def test_task_reminder_utc_reconcile_and_delivery(monkeypatch):
     """Verify that task reminders stored in UTC survive reconciliation and deliver without NameError."""
     from core.scheduler import _add_task_to_scheduler, _execute_task_reminder, scheduler

--- a/tests/test_whiteboard.py
+++ b/tests/test_whiteboard.py
@@ -612,6 +612,42 @@ def test_planner_validate_brief():
 
 
 @pytest.mark.asyncio
+async def test_planning_intake_threads_recent_conversation_into_comprehend_request(monkeypatch):
+    """Regression (#35): WhiteboardPlugin used to read only messages[-1],
+    so a reactive follow-up ("no budget but thinking of...") had no way to
+    resolve against what was actually just discussed. _planning_intake must
+    now pass the recent conversation through to comprehend_request."""
+    from capabilities.whiteboard import planner as wb_planner
+    from orchestrator.router import WhiteboardPlugin
+    from orchestrator.state import AssistantState
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    captured = {}
+
+    async def fake_comprehend(text, board_context=None, recent_context=""):
+        captured["recent_context"] = recent_context
+        return {"action": "none"}
+
+    monkeypatch.setattr(wb_planner, "comprehend_request", fake_comprehend)
+
+    plugin = WhiteboardPlugin()
+    state = AssistantState(
+        messages=[
+            HumanMessage(content="thinking of a bachelor party in Bali sometime in September"),
+            AIMessage(content="Sounds fun! Want me to start a board for it?"),
+            HumanMessage(content="no budget yet but let's figure out venues"),
+        ],
+        user_id=7901,
+    )
+    await plugin.execute(state)
+
+    assert "bachelor party in Bali" in captured["recent_context"]
+    assert "Want me to start a board" in captured["recent_context"]
+    # The current message is the primary `text` argument, not duplicated here.
+    assert "no budget yet but let's figure out venues" not in captured["recent_context"]
+
+
+@pytest.mark.asyncio
 async def test_planning_intake_creates_board_with_entities(monkeypatch):
     """A freeform planning dump becomes one board with status-badged cards."""
     from capabilities.whiteboard import planner as wb_planner
@@ -620,7 +656,7 @@ async def test_planning_intake_creates_board_with_entities(monkeypatch):
     from orchestrator.state import AssistantState
     from langchain_core.messages import HumanMessage
 
-    async def fake_comprehend(text, board_context=None):
+    async def fake_comprehend(text, board_context=None, recent_context=""):
         return {
             "action": "create_board",
             "board_title": "Bali Bachelor Party",
@@ -691,7 +727,7 @@ async def test_planning_intake_augments_recent_board_and_researches(monkeypatch)
     )
     proj_id = create_res["project"]["id"]
 
-    async def fake_comprehend(text, board_context=None):
+    async def fake_comprehend(text, board_context=None, recent_context=""):
         assert board_context is not None
         assert board_context["id"] == proj_id
         return {
@@ -786,7 +822,7 @@ async def test_whiteboard_feedback_message_reaches_planning_intake_not_which_boa
     from orchestrator.state import AssistantState
     from langchain_core.messages import HumanMessage
 
-    async def fake_comprehend(text, board_context=None):
+    async def fake_comprehend(text, board_context=None, recent_context=""):
         return {"action": "none"}
 
     monkeypatch.setattr(wb_planner, "comprehend_request", fake_comprehend)
@@ -830,7 +866,7 @@ async def test_planning_intake_fails_fast_instead_of_hanging_past_webhook_timeou
     # asyncio.wait_for cancellation, not a mock of it.
     monkeypatch.setattr(router_module, "PLANNING_INTAKE_TIMEOUT_SECONDS", 0.05)
 
-    async def slow_comprehend(text, board_context=None):
+    async def slow_comprehend(text, board_context=None, recent_context=""):
         await asyncio.sleep(0.3)  # well past the 0.05s bound above
         return {"action": "none"}  # never reached
 


### PR DESCRIPTION
## What

Closes #35. Domain capability plugins historically read only `messages[-1]`, so a reactive follow-up like *"what about the DBS one instead"*, *"actually make that $20"*, or *"actually from Bugis instead"* had no prior turn to resolve against — each plugin only saw the correction fragment in isolation.

Adds a shared `recent_turns(messages, n=3, exclude_last=True)` helper (`orchestrator/checkpointer.py`) and threads it as **optional, additive grounding context** into each plugin's LLM extraction/summarization call:

| Plugin | Call site | Notes |
|---|---|---|
| Whiteboard | `comprehend_request()` | prepended to `context_lines`, ahead of `board_context` |
| Email | `_summarize_email_results()` | both call sites (fresh + `latest`) |
| Expense | `extract_expense_from_text()` | text path only — the photo-caption path is untouched |
| Recipe | `parse_recipe_and_extract_ingredients()` | |
| Reminder | `parse_reminder_request()` | LLM path only — the deterministic regex fast path is untouched |
| Route | `extract_route_request()` | the bus-arrival path (`handle_bus_query`/`pending_bus_stops`) stays fully deterministic and untouched |

Every prompt is explicitly worded so `recent_context` is scoped to **resolving a correction/continuation of the current message** — never inventing new facts from unrelated earlier turns, and never overriding what the current message actually says. RoutePlugin's existing `last_route`/`is_bare_place_fragment` state-based carry-over logic (from #17/#24) is left as the primary continuation mechanism; `recent_context` is additional grounding on top, not a replacement.

## Why this shape

Per the standing safety boundary in this repo: money-movement and board-altering writes stay behind deterministic guardrails. This change only widens what the LLM *reads* before extracting — it does not change routing, control flow, or any deterministic fast path.

## Testing

- 6 new regression tests (one per plugin), each verified to **fail against pre-fix code** (via `git stash`) and pass with the fix.
- Full suite: `uv run pytest -q` → 300 passed, 8 failed. All 8 failures are pre-existing on `main` (sandbox/env-restricted `test_code_sandbox.py` + `test_recipes.py::test_spend_autopsy_uses_sandbox`, plus `test_planner.py::test_llm_planner_used_when_key_present` and `test_verify.py::test_verify_with_llm_parses_json`) — confirmed unrelated to this change by re-running them against `main` before this branch's commit.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_