### PR TITLE
fix(routes): stop trusting LTA's ignored SearchText param, use local fuzzy catalog match (#57)

### DIFF
--- a/capabilities/routes/lta.py
+++ b/capabilities/routes/lta.py
@@ -41,43 +41,27 @@ async def _lta_get(endpoint: str, params: dict[str, Any]) -> Optional[dict[str, 
 
 
 async def search_bus_stops(search_text: str, limit: int = 5) -> list[dict[str, Any]]:
-    """Search bus stops: live SearchText first, then the local catalog with fuzzy matching."""
+    """Search bus stops via the local catalog, fuzzy-matched against the query.
+
+    Regression (#57): this used to try a "live SearchText" call against LTA's
+    BusStops endpoint first. That endpoint has no free-text search parameter
+    of its own -- per LTA's own API docs it supports only $skip/$top
+    pagination -- so passing SearchText was silently ignored and the call
+    returned an arbitrary, unfiltered page of the full catalog (in practice,
+    always the same handful of stops from the very start of the listing).
+    Because that page was non-empty, it was trusted as the "match" and
+    returned directly, so a query like "fullerton sq hotel" got back
+    completely unrelated stops from Victoria St -- confidently wrong instead
+    of a real match. fuzzy_search_stops() against the real local catalog
+    finds the correct stop; this never had a live-search advantage to give up.
+    """
     global last_search_error
     last_search_error = None
-    api_stops = await _search_api(search_text, limit)
-    if api_stops:
-        return api_stops
-    if _lta_unreachable:
-        last_search_error = "unreachable"
     catalog = await ensure_stop_catalog()
     if catalog is None:
+        last_search_error = "unreachable"
         return []
     return fuzzy_search_stops(catalog, search_text, limit)
-
-
-_lta_unreachable = False
-
-
-async def _search_api(search_text: str, limit: int) -> list[dict[str, Any]]:
-    global _lta_unreachable
-    data = await _lta_get(
-        "BusStops",
-        {"$skip": 0, "SearchText": search_text},
-    )
-    if data is None:
-        _lta_unreachable = True
-        return []
-    _lta_unreachable = False
-    return [
-        {
-            "code": str(stop.get("BusStopCode", "")),
-            "description": stop.get("Description", ""),
-            "road_name": stop.get("RoadName", ""),
-            "lat": stop.get("Latitude"),
-            "lng": stop.get("Longitude"),
-        }
-        for stop in data.get("value", [])[:limit]
-    ]
 
 
 def _normalize(text: str) -> str:

--- a/tests/test_routes_live.py
+++ b/tests/test_routes_live.py
@@ -74,6 +74,58 @@ def test_fuzzy_search_stops_works_offline():
 
 
 @pytest.mark.asyncio
+async def test_search_bus_stops_finds_real_match_not_irrelevant_catalog_page(monkeypatch):
+    """Regression (#57): a query like "fullerton sq hotel" got back unrelated
+    Victoria St stops (Hotel Grand Pacific, St. Joseph's Ch, Bras Basah Cplx)
+    in production because search_bus_stops() trusted a "live SearchText" call
+    against LTA's BusStops endpoint first -- but per LTA's own API docs that
+    endpoint has no free-text search parameter, only $skip/$top pagination,
+    so a real LTA server silently ignores SearchText and returns whatever its
+    first unfiltered page happens to be, every time, regardless of query.
+    Since that page is non-empty it was trusted directly, so the correct
+    local fuzzy match was never even attempted. search_bus_stops() must go
+    straight to the local catalog's fuzzy match, which correctly finds the
+    real "Fullerton Sq" stop over the Victoria St red herrings.
+
+    Mocks _lta_get itself (not search_bus_stops' internals) to faithfully
+    reproduce that real-server behavior: any call carrying "SearchText"
+    returns the same fixed, irrelevant page no matter what text was sent;
+    only the paginated $skip/$top bulk-catalog call returns the real match.
+    """
+    monkeypatch.setattr(settings, "lta_account_key", "test-lta-key")
+
+    victoria_st_page = {
+        "value": [
+            {"BusStopCode": "01012", "Description": "Hotel Grand Pacific", "RoadName": "Victoria St"},
+            {"BusStopCode": "01013", "Description": "St. Joseph's Ch", "RoadName": "Victoria St"},
+            {"BusStopCode": "01019", "Description": "Bras Basah Cplx", "RoadName": "Victoria St"},
+        ]
+    }
+    full_catalog_page = {
+        "value": victoria_st_page["value"] + [
+            {"BusStopCode": "04121", "Description": "Fullerton Sq", "RoadName": "Fullerton Rd"},
+        ]
+    }
+
+    async def fake_lta_get(endpoint, params):
+        assert endpoint == "BusStops"
+        if "SearchText" in params:
+            # Real LTA behavior: SearchText is not a real filter -- always
+            # the same page, regardless of what text was sent.
+            return victoria_st_page
+        if params.get("$skip", 0) > 0:
+            return {"value": []}
+        return full_catalog_page
+
+    monkeypatch.setattr(lta, "_lta_get", fake_lta_get)
+
+    results = await lta.search_bus_stops("fullerton sq hotel")
+    assert results
+    assert results[0]["code"] == "04121"
+    assert results[0]["description"] == "Fullerton Sq"
+
+
+@pytest.mark.asyncio
 async def test_no_live_feed_is_honest_when_key_missing():
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(settings, "lta_account_key", None)


### PR DESCRIPTION
## What

Fixes #57. Root-caused against live Railway production logs for the reported incident:

```
13:38:03 [TG IN]  i want the bus timing at fullerton sq hotel
13:38:16 [TG OUT] Which stop did you mean? - Hotel Grand Pacific (01012, Victoria St) -
                   St. Joseph's Ch (01013, Victoria St) - Bras Basah Cplx (01019, Victoria St)
```

Three stops on a completely different street, with suspiciously low/sequential codes — a signature of "first unfiltered page of the catalog," not a real match.

## Root cause

`search_bus_stops()` tried a "live SearchText" call against LTA DataMall's `BusStops` endpoint first, falling back to the local catalog's fuzzy match only if that returned empty. But per LTA's own API docs, `BusStops` has **no free-text search parameter at all** — only `$skip`/`$top` pagination. A real LTA server silently ignores the unsupported `SearchText` param and returns whatever its default first page happens to be, the same handful of stops regardless of query text. Since that page was non-empty, it was trusted directly and returned as the "match" — so the correct local `fuzzy_search_stops()` path (which *does* find "Fullerton Sq" as a strong 2/3-token match) was never even attempted.

## Fix

`search_bus_stops()` now goes straight to the local catalog (built from LTA's own bulk `$skip`/`$top` pagination, which is real) and fuzzy-matches against it. Removed `_search_api()`/`_lta_unreachable`, which existed only to serve the broken `SearchText` call. Reachability reporting is preserved — `last_search_error` is now set to `"unreachable"` when the catalog's own live fetch fails, which is a strict improvement over before (that specific failure mode previously wasn't reported at all).

## Testing

- New regression test mocks `_lta_get` to faithfully reproduce the real server behavior (SearchText ignored, same page every time regardless of query) — confirmed to fail with `results[0]["code"] == "01012"` (Hotel Grand Pacific) against pre-fix code, and pass with `"04121"` (Fullerton Sq) post-fix.
- Full suite: `uv run pytest -q` → 303 passed, 8 pre-existing failures unrelated to this change (sandbox-restricted env tests + `test_planner`/`test_verify`, unchanged baseline).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_