### PR TITLE
feat(capability): scheduled content delivery — daily news + stock market briefing

### DIFF
--- a/capabilities/manifests/scheduled_content_delivery.yaml
+++ b/capabilities/manifests/scheduled_content_delivery.yaml
@@ -1,0 +1,26 @@
+id: scheduled_content_delivery
+description: >-
+  Set up a recurring briefing delivered to you automatically: a daily morning
+  summary of the top global news and stock market news. Ask like "send me a
+  daily morning summary of the top global news and stock market news", "send
+  me a news briefing every morning", or "brief me on the markets daily".
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+      description: Natural-language request for a recurring news/market briefing.
+  required: [text]
+output_schema:
+  type: object
+  properties:
+    job:
+      type: object
+      description: Scheduled job with cron expression and next run.
+  required: [job]
+side_effect: write
+tags: [news, scheduling, knowledge]
+managers: [life, home]
+preconditions:
+  - "Scheduler is running"
+cost_hint: medium

--- a/capabilities/scheduled_content_delivery/tools.py
+++ b/capabilities/scheduled_content_delivery/tools.py
@@ -1,0 +1,67 @@
+"""Scheduled content delivery: build and push recurring briefings (news + markets)."""
+
+from __future__ import annotations
+
+from core.config import settings
+from core.llm import ThinkingLevel, get_agent_llm
+
+
+async def _search(query: str) -> str:
+    from capabilities.general.tools import search_web
+
+    try:
+        return await search_web.ainvoke({"query": query})
+    except Exception as exc:  # noqa: BLE001
+        return f"[search failed: {exc}]"
+
+
+def _fallback_briefing(news: str, markets: str) -> str:
+    """Deterministic formatting when no LLM key is available."""
+    news_lines = [ln for ln in news.splitlines() if ln.strip()][:6]
+    market_lines = [ln for ln in markets.splitlines() if ln.strip()][:6]
+    if not news_lines and not market_lines:
+        return "No briefing content could be fetched right now."
+    parts = []
+    if news_lines:
+        parts.append("🌍 *Top Global News*\n" + "\n".join(f"• {ln}" for ln in news_lines))
+    if market_lines:
+        parts.append("📈 *Stock Market*\n" + "\n".join(f"• {ln}" for ln in market_lines))
+    return "\n\n".join(parts)
+
+
+async def build_daily_briefing() -> str:
+    """Fetch today's top global news and stock market headlines and format a
+    Telegram-ready morning briefing."""
+    news = await _search("top global news headlines today")
+    markets = await _search("stock market news today")
+
+    fallback = _fallback_briefing(news, markets)
+
+    if not settings.has_llm_key:
+        return fallback
+
+    try:
+        llm = get_agent_llm(complexity=ThinkingLevel.LOW, temperature=0.4)
+        ai_message = await llm.ainvoke(
+            [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are Nexus Prime. Build a concise morning briefing from "
+                        "the raw web-search results below. Two sections: 🌍 Top Global News "
+                        "and 📈 Stock Market. 3-5 bullet lines per section, bold headers, "
+                        "Telegram-friendly. Never invent facts or headlines that are not "
+                        "present in the provided text."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": f"Global news:\n{news[:3000]}\n\nStock market:\n{markets[:3000]}",
+                },
+            ]
+        )
+        content = str(getattr(ai_message, "content", "") or "").strip()
+        return content or fallback
+    except Exception as exc:  # noqa: BLE001
+        print(f"[BRIEFING] summary LLM failed, using fallback: {exc}")
+        return fallback

--- a/config/tag-policy.yaml
+++ b/config/tag-policy.yaml
@@ -22,6 +22,8 @@ allowed_tags:
   - web
   - knowledge
   - chat
+  - news
+  - briefing
   - link
   - url
   - fetch

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -38,6 +38,7 @@ async def _execute_scheduled_job(job_id: int, user_id: int, instruction_prompt: 
     try:
         chat_id = None
         tz_name = "Asia/Singapore"
+        job_name = ""
         async with async_session_factory() as session:
             profile = (
                 await session.execute(
@@ -53,6 +54,12 @@ async def _execute_scheduled_job(job_id: int, user_id: int, instruction_prompt: 
                 except Exception:
                     pass
             tz_name = profile.current_timezone if profile and profile.current_timezone else tz_name
+            job_row = (
+                await session.execute(
+                    select(ScheduledJob).where(ScheduledJob.id == job_id)
+                )
+            ).scalar_one_or_none()
+            job_name = job_row.job_name if job_row else ""
         if not chat_id:
             print(f"[SCHEDULER] Cannot deliver scheduled job {job_id}: no valid telegram chat_id found for user {user_id}")
             return
@@ -73,6 +80,20 @@ async def _execute_scheduled_job(job_id: int, user_id: int, instruction_prompt: 
             return
 
         from app.ingress import send_telegram_message
+
+        if job_name == "daily_briefing":
+            from capabilities.scheduled_content_delivery.tools import build_daily_briefing
+
+            try:
+                briefing = await build_daily_briefing()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[SCHEDULER] briefing build failed for job {job_id}: {exc}")
+                briefing = None
+            if not briefing:
+                print(f"[SCHEDULER] empty briefing for job {job_id}; skipping delivery")
+                return
+            await send_telegram_message(chat_id, f"📰 *Morning Briefing*\n\n{briefing}")
+            return
 
         await send_telegram_message(
             chat_id,

--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -293,6 +293,12 @@ def _candidate_selections(text: str, missing: list[str]) -> list[CapabilitySelec
 
     add("reminders", ["remind", "reminder", "cron"], "reminder/scheduling intent")
 
+    add("scheduled_content_delivery", [
+        "daily morning summary", "news briefing", "stock market news",
+        "daily briefing", "morning briefing", "news summary", "briefing of the",
+        "global news and stock", "send me a daily",
+    ], "scheduled content delivery intent")
+
     add("whiteboard", [
         "whiteboard", "white board", "planning board", " boards",
         "plan a trip", "plan my trip", "plan our trip", "plan a", "plan my",

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1381,6 +1381,59 @@ class ReminderPlugin:
         )
 
 
+class ScheduledContentDeliveryPlugin:
+    """Schedules and delivers recurring content briefings (news, stock markets)."""
+
+    name = "scheduled_content_delivery"
+    keywords = ["news briefing", "daily briefing", "morning summary", "stock market", "news"]
+    description = "Schedules recurring briefings of top global news and stock market news."
+
+    async def execute(self, state: AssistantState) -> PluginOutput:
+        user_id = state["user_id"]
+        messages = state.get("messages", [])
+        last_text = str(messages[-1].content) if messages else ""
+        lowered = last_text.lower()
+
+        from capabilities.scheduled_content_delivery.tools import build_daily_briefing
+
+        is_schedule_request = any(
+            phrase in lowered
+            for phrase in (
+                "daily", "every morning", "every day", "recurring", "each morning",
+                "schedule", "morning summary", "morning briefing",
+            )
+        )
+        if is_schedule_request:
+            from core.scheduler import schedule_proactive_task
+
+            try:
+                job = await schedule_proactive_task(
+                    user_id=user_id,
+                    job_name="daily_briefing",
+                    cron_expression="0 9 * * *",
+                    instruction_prompt="Daily morning briefing: top global news and stock market news",
+                    timezone_str="Asia/Singapore",
+                )
+                reply = (
+                    "📰 Done! I'll send you a **daily morning briefing** of the top "
+                    "global news and stock market news at **09:00** every day.\n"
+                    f"Job #`{job.id}` — manage it anytime with /jobs."
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"[BRIEFING] schedule failed: {exc}")
+                reply = "⚠️ Couldn't schedule the briefing right now — try again in a moment."
+            return PluginOutput(
+                message=AIMessage(content=reply),
+                state_update={"active_domain": self.name},
+            )
+
+        briefing = await build_daily_briefing()
+        return PluginOutput(
+            message=AIMessage(content=briefing),
+            state_update={"active_domain": self.name},
+        )
+
+
 # Regression: _planning_intake() chains a comprehend_request() LLM call
 # (bounded to LLM_REQUEST_TIMEOUT_SECONDS=30s, see core/llm.py) followed by a
 # concurrent research pass (each query bounded to RESEARCH_QUERY_TIMEOUT_SECONDS
@@ -1937,6 +1990,7 @@ CAPABILITY_REGISTRY: Dict[str, CapabilityPlugin] = {
     "routes": RoutePlugin(),
     "recipes": RecipePlugin(),
     "reminders": ReminderPlugin(),
+    "scheduled_content_delivery": ScheduledContentDeliveryPlugin(),
     "whiteboard": WhiteboardPlugin(),
     "general": GeneralPlugin(),
 }

--- a/tests/test_scheduled_content_delivery.py
+++ b/tests/test_scheduled_content_delivery.py
@@ -1,0 +1,91 @@
+import pytest
+from langchain_core.messages import HumanMessage
+from unittest.mock import AsyncMock, patch
+
+from capabilities.scheduled_content_delivery.tools import _fallback_briefing, build_daily_briefing
+
+
+def test_fallback_briefing_formats_sections():
+    news = "Summary: Big headline\n- Title (url): content\n- Title2 (url2): content2"
+    markets = "Summary: Markets up\n- Title (url): content"
+    text = _fallback_briefing(news, markets)
+    assert "🌍 *Top Global News*" in text
+    assert "📈 *Stock Market*" in text
+    assert "Big headline" in text
+
+
+def test_fallback_briefing_empty():
+    text = _fallback_briefing("", "")
+    assert text == "No briefing content could be fetched right now."
+
+
+@pytest.mark.asyncio
+async def test_build_daily_briefing_without_llm(monkeypatch):
+    async def fake_search(query: str) -> str:
+        if "stock" in query:
+            return "Summary: Stocks rally\n- Tech (http://x): gains"
+        return "Summary: Global headline\n- News (http://y): details"
+
+    monkeypatch.setattr(
+        "capabilities.scheduled_content_delivery.tools._search",
+        fake_search,
+    )
+    text = await build_daily_briefing()
+    assert "Top Global News" in text
+    assert "Stock Market" in text
+    assert "Global headline" in text
+
+
+@pytest.mark.asyncio
+async def test_plugin_registers_daily_briefing_job(monkeypatch):
+    from orchestrator.router import ScheduledContentDeliveryPlugin
+
+    class _FakeJob:
+        id = 4242
+
+    fake_schedule = AsyncMock(return_value=_FakeJob())
+    monkeypatch.setattr("core.scheduler.schedule_proactive_task", fake_schedule)
+
+    state = {
+        "user_id": 1,
+        "messages": [HumanMessage(content="Can you send me a daily morning summary of the top global news and stock market news")],
+    }
+    output = await ScheduledContentDeliveryPlugin().execute(state)
+    assert "daily morning briefing" in output.message.content
+    assert "4242" in output.message.content
+    args = fake_schedule.await_args.kwargs
+    assert args["job_name"] == "daily_briefing"
+    assert args["cron_expression"] == "0 9 * * *"
+
+
+@pytest.mark.asyncio
+async def test_plugin_one_shot_briefing(monkeypatch):
+    from orchestrator.router import ScheduledContentDeliveryPlugin
+
+    monkeypatch.setattr(
+        "capabilities.scheduled_content_delivery.tools.build_daily_briefing",
+        AsyncMock(return_value="📰 Today's briefing content"),
+    )
+    state = {
+        "user_id": 1,
+        "messages": [HumanMessage(content="what's the market news today?")],
+    }
+    output = await ScheduledContentDeliveryPlugin().execute(state)
+    assert "Today's briefing content" in output.message.content
+
+
+def test_deterministic_plan_routes_daily_briefing():
+    from orchestrator.planner import deterministic_plan
+
+    state = {
+        "user_id": 1,
+        "active_domain": None,
+        "last_decision": None,
+        "messages": [HumanMessage(content="Can you send me a daily morning summary of the top global news and stock market news")],
+    }
+    decision = deterministic_plan(
+        "Can you send me a daily morning summary of the top global news and stock market news",
+        state,
+        None,
+    )
+    assert "scheduled_content_delivery" in decision.capability_ids


### PR DESCRIPTION
## Closes #30

Implements the capability-gap wishlist issue: "Can you send me a daily morning summary of the top global news and stock market news" was being refused with `#scheduled_content_delivery`. Now a first-class capability.

## What it does

- **New `scheduled_content_delivery` capability** (manifest + plugin + tools)
- `build_daily_briefing()` — fetches top global news + stock market headlines via the existing Tavily `search_web` tool, summarizes with the agent LLM (deterministic sectioned fallback without a key)
- **Two intents handled by the plugin:**
  - *Schedule* ("send me a daily morning summary…") → registers a `daily_briefing` ScheduledJob at 09:00 Asia/Singapore (after quiet hours) via `schedule_proactive_task`, manageable via `/jobs`
  - *One-shot* ("what's the market news today?") → generates the briefing immediately
- **`_execute_scheduled_job`** special-cases `daily_briefing` to build and push real content (still gated by `should_deliver` quiet hours), instead of a canned reminder
- **Routing** — deterministic planner keywords + manifest/tags make the capability retrievable for both planner paths

## Tests

6 new. Full suite (excluding optional hypothesis fuzz file): **315 passed**.