### PR TITLE
feat(capability): bug logging — user-reported bugs flow to the issue tracker

### DIFF
--- a/capabilities/bug_logging/tools.py
+++ b/capabilities/bug_logging/tools.py
@@ -1,0 +1,109 @@
+"""Bug logging: user-reported bugs flow into the production-bug pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict
+
+
+def _extract_bug_description(text: str) -> str:
+    """Strip bug-report framing so the issue body is the actual problem."""
+    cleaned = re.sub(
+        r"^\s*(?:please\s+)?(?:can you\s+|could you\s+|kindly\s+)?"
+        r"(?:log|file|report|record)\s+(?:it|this|that)?\s*(?:as\s+)?(?:a\s+)?"
+        r"(?:bug|issue|problem)\b[\.!]?\s*",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    ).strip()
+    cleaned = re.sub(r"^:\s*", "", cleaned).strip()
+    cleaned = re.sub(
+        r"\s*(?:please\s+)?(?:log|file|report)\s+(?:it|this|that)\s*(?:as\s+)?"
+        r"(?:a\s+)?(?:bug|issue|problem)\b\.?\s*$",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    ).strip()
+    return cleaned or text.strip()
+
+
+def _guess_subsystem(description: str) -> str:
+    lowered = description.lower()
+    surface = {
+        "cockpit": "dashboard",
+        "dashboard": "dashboard",
+        "icon": "dashboard",
+        "splitting": "dashboard",
+        "split": "dashboard",
+        "transaction": "dashboard",
+        "ui": "dashboard",
+        "interface": "dashboard",
+        "telegram": "telegram",
+        "bot": "telegram",
+        "email": "email",
+        "gmail": "email",
+        "expense": "expenses",
+        "receipt": "expenses",
+        "route": "routes",
+        "bus": "routes",
+        "reminder": "reminders",
+        "recipe": "recipes",
+        "grocery": "recipes",
+        "whiteboard": "whiteboard",
+        "board": "whiteboard",
+    }
+    for keyword, subsystem in surface.items():
+        if re.search(rf"\b{re.escape(keyword)}\b", lowered):
+            return subsystem
+    return "general"
+
+
+def _stable_fingerprint(description: str) -> str:
+    """Deterministic fingerprint so identical reports dedup into one issue."""
+    normalized = re.sub(r"\s+", " ", description.strip().lower())
+    digest = hashlib.md5(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"userbug_{digest}"
+
+
+async def log_user_bug(
+    user_id: int,
+    description: str,
+    subsystem: str = "general",
+) -> Dict[str, Any]:
+    """Record a user-reported bug through the production-bug pipeline."""
+    from core.audit import record_operation_event
+
+    record = await record_operation_event(
+        subsystem=subsystem,
+        error_context=description[:2000],
+        detection_source="user_reported",
+        user_id=user_id,
+        fingerprint=_stable_fingerprint(description),
+        severity="P3",
+        title=f"User-reported: {description[:80]}",
+    )
+    if not record:
+        return {"logged": False}
+
+    url = None
+    number = None
+    try:
+        from core.db import async_session_factory
+        from core.models import ProductionBugLog
+
+        async with async_session_factory() as session:
+            db_entry = await session.get(ProductionBugLog, record.id)
+            if db_entry:
+                url = db_entry.github_issue_url
+                number = db_entry.github_issue_number
+    except Exception:  # noqa: BLE001 - URL is best-effort after the write
+        pass
+
+    return {
+        "logged": True,
+        "bug_id": record.id,
+        "github_issue_url": url,
+        "github_issue_number": number,
+        "occurrence_count": record.occurrence_count,
+    }

--- a/capabilities/manifests/bug_logging.yaml
+++ b/capabilities/manifests/bug_logging.yaml
@@ -1,0 +1,25 @@
+id: bug_logging
+description: >-
+  Log a bug or issue the user noticed (in the cockpit, a skill, or an
+  integration) into the production-bug pipeline and GitHub issue backlog.
+  Ask like "log it as a bug: the split icon is missing next to edit", "there
+  seems to be an issue with the cockpit", or "can you report a bug".
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+      description: Natural-language bug report.
+  required: [text]
+output_schema:
+  type: object
+  properties:
+    bug:
+      type: object
+      description: Logged bug with GitHub issue URL when synced.
+  required: [bug]
+side_effect: write
+tags: [bug, knowledge]
+managers: [life, home]
+preconditions: []
+cost_hint: low

--- a/config/tag-policy.yaml
+++ b/config/tag-policy.yaml
@@ -24,6 +24,8 @@ allowed_tags:
   - chat
   - news
   - briefing
+  - bug
+  - issue
   - link
   - url
   - fetch

--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -293,6 +293,12 @@ def _candidate_selections(text: str, missing: list[str]) -> list[CapabilitySelec
 
     add("reminders", ["remind", "reminder", "cron"], "reminder/scheduling intent")
 
+    add("bug_logging", [
+        "log it as a bug", "log a bug", "report a bug", "file a bug",
+        "log this as a bug", "log that as a bug", "bug report",
+        "there seems to be an issue with", "there is an issue with",
+    ], "bug logging intent")
+
     add("scheduled_content_delivery", [
         "daily morning summary", "news briefing", "stock market news",
         "daily briefing", "morning briefing", "news summary", "briefing of the",

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1381,6 +1381,58 @@ class ReminderPlugin:
         )
 
 
+class BugLoggingPlugin:
+    """Logs user-reported bugs into the production-bug pipeline and GitHub issues."""
+
+    name = "bug_logging"
+    keywords = ["bug", "log it as a bug", "report a bug", "issue with the cockpit"]
+    description = "Logs bugs the user notices into the GitHub issue backlog."
+
+    async def execute(self, state: AssistantState) -> PluginOutput:
+        user_id = state["user_id"]
+        messages = state.get("messages", [])
+        last_text = str(messages[-1].content) if messages else ""
+
+        from capabilities.bug_logging.tools import (
+            _extract_bug_description,
+            _guess_subsystem,
+            log_user_bug,
+        )
+
+        description = _extract_bug_description(last_text)
+        subsystem = _guess_subsystem(description or last_text)
+        result = await log_user_bug(
+            user_id=user_id,
+            description=description or last_text,
+            subsystem=subsystem,
+        )
+        if not result.get("logged"):
+            return PluginOutput(
+                message=AIMessage(
+                    content=(
+                        "🐞 I couldn't log that bug right now — please try again "
+                        "in a moment, or describe what you saw in more detail."
+                    )
+                ),
+                state_update={"active_domain": self.name},
+            )
+        url = result.get("github_issue_url")
+        if url:
+            reply = (
+                f"🐞 Logged it as a bug — thank you! I filed it in the tracker:\n"
+                f"{url}"
+            )
+        else:
+            reply = (
+                "🐞 Logged it as a bug — thank you! It's recorded locally and "
+                "will sync to the issue tracker when GitHub is configured."
+            )
+        return PluginOutput(
+            message=AIMessage(content=reply),
+            state_update={"active_domain": self.name},
+        )
+
+
 class ScheduledContentDeliveryPlugin:
     """Schedules and delivers recurring content briefings (news, stock markets)."""
 
@@ -1991,6 +2043,7 @@ CAPABILITY_REGISTRY: Dict[str, CapabilityPlugin] = {
     "recipes": RecipePlugin(),
     "reminders": ReminderPlugin(),
     "scheduled_content_delivery": ScheduledContentDeliveryPlugin(),
+    "bug_logging": BugLoggingPlugin(),
     "whiteboard": WhiteboardPlugin(),
     "general": GeneralPlugin(),
 }

--- a/tests/test_bug_logging.py
+++ b/tests/test_bug_logging.py
@@ -1,0 +1,103 @@
+import pytest
+from langchain_core.messages import HumanMessage
+from unittest.mock import AsyncMock, patch
+
+from capabilities.bug_logging.tools import (
+    _extract_bug_description,
+    _guess_subsystem,
+    _stable_fingerprint,
+    log_user_bug,
+)
+
+
+def test_extract_bug_description_strips_framing():
+    assert _extract_bug_description(
+        "Can you log it as a bug. There is no icon for transaction splitting beside the edit icon."
+    ) == "There is no icon for transaction splitting beside the edit icon."
+    assert _extract_bug_description(
+        "please log this as a bug: the dashboard is slow"
+    ) == "the dashboard is slow"
+    assert _extract_bug_description("There seems to be an issue with the cockpit") == (
+        "There seems to be an issue with the cockpit"
+    )
+
+
+def test_guess_subsystem():
+    assert _guess_subsystem("no icon for transaction splitting beside the edit icon") == "dashboard"
+    assert _guess_subsystem("the telegram bot didn't reply") == "telegram"
+    assert _guess_subsystem("the bus timing was wrong") == "routes"
+    assert _guess_subsystem("something weird happened") == "general"
+
+
+def test_stable_fingerprint_dedups():
+    a = _stable_fingerprint("There is no icon for splitting  beside the edit icon")
+    b = _stable_fingerprint("There is no icon for splitting beside the edit icon")
+    c = _stable_fingerprint("completely different bug")
+    assert a == b
+    assert a != c
+
+
+@pytest.mark.asyncio
+async def test_log_user_bug_returns_issue_url():
+    mock_result = {
+        "url": "https://github.com/owner/repo/issues/88",
+        "number": 88,
+    }
+    with patch(
+        "core.audit.sync_production_bug_to_github_issue",
+        new=AsyncMock(return_value=mock_result),
+    ):
+        result = await log_user_bug(
+            user_id=1,
+            description="no split icon next to edit",
+            subsystem="dashboard",
+        )
+    assert result["logged"] is True
+    assert result["github_issue_url"] == "https://github.com/owner/repo/issues/88"
+
+
+@pytest.mark.asyncio
+async def test_bug_logging_plugin_replies_with_url(monkeypatch):
+    from orchestrator.router import BugLoggingPlugin
+
+    monkeypatch.setattr(
+        "capabilities.bug_logging.tools.log_user_bug",
+        AsyncMock(
+            return_value={
+                "logged": True,
+                "bug_id": 1,
+                "github_issue_url": "https://github.com/owner/repo/issues/88",
+                "github_issue_number": 88,
+                "occurrence_count": 1,
+            }
+        ),
+    )
+    state = {
+        "user_id": 1,
+        "messages": [
+            HumanMessage(
+                content="There seems to be an issue with the cockpit. There is no icon "
+                "for transaction splitting beside the edit icon. Can you log it as a bug."
+            )
+        ],
+    }
+    output = await BugLoggingPlugin().execute(state)
+    assert "issues/88" in output.message.content
+    assert "Logged it as a bug" in output.message.content
+
+
+def test_deterministic_plan_routes_bug_logging():
+    from orchestrator.planner import deterministic_plan
+
+    state = {
+        "user_id": 1,
+        "active_domain": None,
+        "last_decision": None,
+        "messages": [HumanMessage(content="There seems to be an issue with the cockpit. Can you log it as a bug.")],
+    }
+    decision = deterministic_plan(
+        "There seems to be an issue with the cockpit. Can you log it as a bug.",
+        state,
+        None,
+    )
+    assert "bug_logging" in decision.capability_ids


### PR DESCRIPTION
## Closes #14

Implements the capability-gap wishlist issue: "Can you log it as a bug" was being refused with `#bug_logging`. Now a first-class capability.

## What it does

- **New `bug_logging` capability** (manifest + plugin + tools)
- Plugin strips bug-report framing ("can you log it as a bug") → captures the actual problem
- Guesses the affected subsystem (cockpit/dashboard, telegram, email, routes, expenses, ...)
- Records through the **deterministic production-bug pipeline** (`record_operation_event`): persists a `ProductionBugLog` row, dedups identical reports into one open issue + recurrence comment, syncs to GitHub Issues when configured
- **Stable per-description fingerprint** (`userbug_<md5>`) — same bug twice = one issue, not two
- **Routing** — deterministic planner keywords ("log it as a bug", "report a bug", "there seems to be an issue with …") + manifest/tags for both planner paths

## Tests

6 new. Full suite (excluding optional hypothesis fuzz file): **321 passed**.