### PR TITLE
feat(capability): personal memory — points/miles balances (slice #1)

### DIFF
--- a/capabilities/manifests/memory.yaml
+++ b/capabilities/manifests/memory.yaml
@@ -1,0 +1,26 @@
+id: memory
+description: >-
+  Remember and recall structured personal facts about the user. Slice #1:
+  loyalty points/miles balances — "I have 12000 DBS points expiring soon",
+  "my Citibank miles balance is 45000", or "what are my points balances?"
+  Records are stored per bank/airline and updated (not duplicated) when the
+  same program is mentioned again.
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+      description: Natural-language points/miles balance statement or recall question.
+  required: [text]
+output_schema:
+  type: object
+  properties:
+    facts:
+      type: array
+      description: Stored personal facts (issuer, program, balance, expiry).
+  required: [facts]
+side_effect: write
+tags: [memory, knowledge]
+managers: [life, home]
+preconditions: []
+cost_hint: low

--- a/capabilities/memory/tools.py
+++ b/capabilities/memory/tools.py
@@ -1,0 +1,173 @@
+"""Personal memory slice #1: loyalty points/miles balances.
+
+Structured, per-user records keyed by (issuer, program). A new statement
+upserts the existing balance rather than appending; recall lists them back.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone as dt_timezone
+from typing import Any, Dict, List, Optional
+
+from sqlmodel import select
+
+from core.config import settings
+from core.db import async_session_factory
+from core.llm import ThinkingLevel, get_agent_llm
+from core.models import PointsBalance
+
+KNOWN_ISSUERS = ("dbs", "citibank", "citi", "uob", "ocbc", "maybank", "krisflyer", "sia", "amex", "american express")
+
+
+def _normalize_issuer(raw: str) -> str:
+    lowered = (raw or "").strip().lower()
+    if lowered in {"citi", "citibank"}:
+        return "Citibank"
+    if lowered in {"krisflyer", "sia"}:
+        return "KrisFlyer"
+    if lowered in {"american express", "amex"}:
+        return "Amex"
+    if lowered in {"dbs", "posb"}:
+        return "DBS"
+    if lowered in {"uob"}:
+        return "UOB"
+    if lowered in {"ocbc"}:
+        return "OCBC"
+    if lowered in {"maybank"}:
+        return "Maybank"
+    return (raw or "").strip().title() or "Unknown"
+
+
+def _regex_extract_points(text: str) -> Optional[Dict[str, Any]]:
+    """Deterministic fallback when no LLM key is available."""
+    lowered = (text or "").lower()
+    # Number before unit: "12000 DBS reward points", "45000 miles".
+    before = re.search(
+        r"(\d[\d,.]*)\s+(?:[a-z0-9&' ]+?\s+){0,3}(?:reward\s*)?(?:points|miles)\b", lowered
+    )
+    # Number after unit: "miles balance is 45000", "points: 12000".
+    after = re.search(
+        r"\b(?:points|miles)\b[^\d]{0,30}?(\d[\d,.]*)", lowered
+    )
+    match = before or after
+    if not match:
+        return None
+    balance = float((match.group(1) or match.group(2)).replace(",", ""))
+    issuer = None
+    for known in KNOWN_ISSUERS:
+        if known in lowered:
+            issuer = _normalize_issuer(known)
+            break
+    program = None
+    prog_match = re.search(r"([a-z0-9&' ]+?)\s+(?:reward\s*)?points", lowered)
+    if prog_match:
+        candidate = prog_match.group(1).strip()
+        if candidate and candidate not in {"i have", "have", "earned", "got", "for", "with", "about", "my"}:
+            program = candidate.title()
+    return {"issuer": issuer, "program": program, "balance": balance}
+
+
+async def extract_points_balance(user_text: str) -> Dict[str, Any]:
+    """Extract a points/miles balance mention into structured fields."""
+    if not settings.has_llm_key:
+        return _regex_extract_points(user_text) or {}
+
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    try:
+        llm = get_agent_llm(complexity=ThinkingLevel.LOW, temperature=0.0)
+        ai_message = await llm.ainvoke(
+            [
+                SystemMessage(
+                    content=(
+                        "Extract a loyalty points/miles balance from the user's message. "
+                        "Reply with ONLY JSON: "
+                        '{"issuer": string|null, "program": string|null, "balance": number|null, '
+                        '"expiry": string|null (ISO date)}. '
+                        'issuer is the bank/airline (DBS, Citibank, UOB, KrisFlyer, Amex, ...). '
+                        "If the message does not contain a points/miles balance statement, "
+                        'return {"balance": null}. Never invent values.'
+                    )
+                ),
+                HumanMessage(content=(user_text or "")[:2000]),
+            ]
+        )
+        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
+        import json
+
+        parsed = json.loads(raw)
+        balance = parsed.get("balance")
+        if balance is None:
+            return {}
+        return {
+            "issuer": _normalize_issuer(parsed.get("issuer") or ""),
+            "program": (parsed.get("program") or "").strip().title() or None,
+            "balance": float(balance),
+            "expiry": parsed.get("expiry") or None,
+        }
+    except Exception as exc:  # noqa: BLE001
+        print(f"[MEMORY] extraction LLM failed, using regex: {exc}")
+        return _regex_extract_points(user_text) or {}
+
+
+async def upsert_points_balance(
+    user_id: int,
+    issuer: str,
+    program: Optional[str] = None,
+    balance: Optional[float] = None,
+    expiry: Optional[str] = None,
+) -> Optional[PointsBalance]:
+    """Upsert a points/miles balance by (user_id, issuer, program)."""
+    clean_issuer = _normalize_issuer(issuer)
+    clean_program = (program or "").strip() or ""
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(PointsBalance).where(
+                PointsBalance.user_id == user_id,
+                PointsBalance.issuer == clean_issuer,
+                PointsBalance.program == clean_program,
+            )
+        )
+        record = result.scalar_one_or_none()
+        if record is None:
+            record = PointsBalance(
+                user_id=user_id,
+                issuer=clean_issuer,
+                program=clean_program,
+                balance=balance or 0.0,
+                updated_at=datetime.now(dt_timezone.utc),
+            )
+        else:
+            if balance is not None:
+                record.balance = balance
+            record.updated_at = datetime.now(dt_timezone.utc)
+        if expiry:
+            try:
+                record.expiry_date = datetime.fromisoformat(str(expiry).replace("Z", "+00:00"))
+            except Exception:
+                pass
+        session.add(record)
+        await session.commit()
+        await session.refresh(record)
+        return record
+
+
+async def query_points_balances(user_id: int) -> List[Dict[str, Any]]:
+    """List all stored points/miles balances for a user."""
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(PointsBalance).where(PointsBalance.user_id == user_id).order_by(PointsBalance.issuer)
+        )
+        rows = result.scalars().all()
+        return [
+            {
+                "issuer": r.issuer,
+                "program": r.program or None,
+                "balance": r.balance,
+                "expiry": r.expiry_date.isoformat() if r.expiry_date else None,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in rows
+        ]

--- a/config/tag-policy.yaml
+++ b/config/tag-policy.yaml
@@ -26,6 +26,7 @@ allowed_tags:
   - briefing
   - bug
   - issue
+  - memory
   - link
   - url
   - fetch

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import List, Optional, Dict, Any
-from sqlmodel import SQLModel, Field, Column, JSON
+from sqlmodel import SQLModel, Field, Column, JSON, UniqueConstraint
 
 class UserProfile(SQLModel, table=True):
     user_id: int = Field(primary_key=True)  # Telegram User ID
@@ -96,6 +96,25 @@ class TaskItem(SQLModel, table=True):
     iou_amount: Optional[float] = Field(default=None)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: Optional[datetime] = Field(default=None)
+
+
+class PointsBalance(SQLModel, table=True):
+    """Personal memory slice #1: loyalty points/miles balances per issuer+program.
+
+    Upserted by (user_id, issuer, program) so a fresh statement photo updates
+    the existing balance instead of appending a new row.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="userprofile.user_id", index=True)
+    issuer: str = Field(index=True)  # e.g. "DBS", "Citibank", "UOB"
+    program: str = Field(default="", index=True)  # e.g. "DBS Rewards"; "" = issuer-level
+    balance: float = Field(default=0.0)
+    expiry_date: Optional[datetime] = Field(default=None)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "issuer", "program", name="uq_points_user_issuer_program"),
+    )
 
 
 class WhiteboardProject(SQLModel, table=True):

--- a/orchestrator/planner.py
+++ b/orchestrator/planner.py
@@ -299,6 +299,13 @@ def _candidate_selections(text: str, missing: list[str]) -> list[CapabilitySelec
         "there seems to be an issue with", "there is an issue with",
     ], "bug logging intent")
 
+    add("memory", [
+        "points balance", "miles balance", "reward points", "my points",
+        "my miles", "dbs points", "citibank points", "uob points",
+        "krisflyer", "miles expiring", "points expiring", "how many points",
+        "how many miles", "what are my points", "what are my miles",
+    ], "personal memory points/miles intent")
+
     add("scheduled_content_delivery", [
         "daily morning summary", "news briefing", "stock market news",
         "daily briefing", "morning briefing", "news summary", "briefing of the",

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1381,6 +1381,86 @@ class ReminderPlugin:
         )
 
 
+class MemoryPlugin:
+    """Personal memory: records and recalls structured user facts (slice #1: points/miles)."""
+
+    name = "memory"
+    keywords = ["points", "miles", "balance", "reward", "remember"]
+    description = "Remembers structured personal facts — points/miles balances first."
+
+    async def execute(self, state: AssistantState) -> PluginOutput:
+        user_id = state["user_id"]
+        messages = state.get("messages", [])
+        last_text = str(messages[-1].content) if messages else ""
+
+        from capabilities.memory.tools import (
+            extract_points_balance,
+            query_points_balances,
+            upsert_points_balance,
+        )
+
+        lowered = last_text.lower()
+        recall_intent = any(
+            phrase in lowered
+            for phrase in (
+                "what are my", "how many points", "how many miles", "my points",
+                "my miles", "points balance", "miles balance", "reward balance",
+                "list my points", "list my miles",
+            )
+        )
+        if recall_intent or ("point" in lowered and ("?" in last_text or "balance" in lowered)):
+            rows = await query_points_balances(user_id)
+            if not rows:
+                reply = (
+                    "🧠 I don't have any points/miles balances saved yet. Tell me "
+                    "*\"I have 12000 DBS points\"* or *\"my Citibank miles balance "
+                    "is 45000\"* and I'll remember it."
+                )
+            else:
+                lines = ["🧠 **Your Points & Miles Balances**:"]
+                for row in rows:
+                    label = row["program"] or row["issuer"]
+                    expiry = f" · exp {row['expiry'][:10]}" if row.get("expiry") else ""
+                    lines.append(f"• *{label}*: {row['balance']:,.0f}{expiry}")
+                lines.append("\nSend me an updated balance and I'll update it.")
+                reply = "\n".join(lines)
+            return PluginOutput(
+                message=AIMessage(content=reply),
+                state_update={"active_domain": self.name},
+            )
+
+        extracted = await extract_points_balance(last_text)
+        if not extracted.get("balance"):
+            reply = (
+                "🧠 I can remember your points/miles balances — try *\"I have 12000 "
+                "DBS points expiring next month\"* or *\"what are my points balances?\"*."
+            )
+            return PluginOutput(
+                message=AIMessage(content=reply),
+                state_update={"active_domain": self.name},
+            )
+
+        record = await upsert_points_balance(
+            user_id=user_id,
+            issuer=extracted.get("issuer") or "Unknown",
+            program=extracted.get("program"),
+            balance=float(extracted["balance"]),
+            expiry=extracted.get("expiry"),
+        )
+        label = (record.program or record.issuer)
+        expiry_note = ""
+        if record.expiry_date:
+            expiry_note = f", expiring {record.expiry_date.strftime('%d %b %Y')}"
+        reply = (
+            f"🧠 Got it — *{label}*: **{record.balance:,.0f}** points/miles saved{expiry_note}. "
+            "Ask *\"what are my points balances?\"* anytime to see them."
+        )
+        return PluginOutput(
+            message=AIMessage(content=reply),
+            state_update={"active_domain": self.name},
+        )
+
+
 class BugLoggingPlugin:
     """Logs user-reported bugs into the production-bug pipeline and GitHub issues."""
 
@@ -2044,6 +2124,7 @@ CAPABILITY_REGISTRY: Dict[str, CapabilityPlugin] = {
     "reminders": ReminderPlugin(),
     "scheduled_content_delivery": ScheduledContentDeliveryPlugin(),
     "bug_logging": BugLoggingPlugin(),
+    "memory": MemoryPlugin(),
     "whiteboard": WhiteboardPlugin(),
     "general": GeneralPlugin(),
 }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,104 @@
+import pytest
+from langchain_core.messages import HumanMessage
+from unittest.mock import AsyncMock, patch
+
+from capabilities.memory.tools import (
+    _normalize_issuer,
+    _regex_extract_points,
+    extract_points_balance,
+    query_points_balances,
+    upsert_points_balance,
+)
+
+
+def test_normalize_issuer():
+    assert _normalize_issuer("citibank") == "Citibank"
+    assert _normalize_issuer("CITI") == "Citibank"
+    assert _normalize_issuer("krisflyer") == "KrisFlyer"
+    assert _normalize_issuer("dbs") == "DBS"
+    assert _normalize_issuer("posb") == "DBS"
+    assert _normalize_issuer("random") == "Random"
+
+
+def test_regex_extract_points():
+    result = _regex_extract_points("I have 12000 DBS reward points expiring next month")
+    assert result["balance"] == 12000.0
+    assert result["issuer"] == "DBS"
+    assert _regex_extract_points("no points here") is None
+
+
+def test_regex_extract_miles():
+    result = _regex_extract_points("my Citibank miles balance is 45000")
+    assert result["balance"] == 45000.0
+    assert result["issuer"] == "Citibank"
+
+
+@pytest.mark.asyncio
+async def test_extract_points_balance_falls_back_to_regex_without_llm():
+    result = await extract_points_balance("I have 12000 DBS points")
+    assert result["balance"] == 12000.0
+    assert result["issuer"] == "DBS"
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_existing_balance_not_append():
+    first = await upsert_points_balance(user_id=777001, issuer="DBS", program="DBS Rewards", balance=12000)
+    second = await upsert_points_balance(user_id=777001, issuer="DBS", program="DBS Rewards", balance=13500)
+    assert first.id == second.id
+    rows = await query_points_balances(user_id=777001)
+    assert len(rows) == 1
+    assert rows[0]["balance"] == 13500.0
+    assert rows[0]["program"] == "DBS Rewards"
+
+
+@pytest.mark.asyncio
+async def test_query_returns_all_balances():
+    await upsert_points_balance(user_id=777002, issuer="Citibank", balance=45000)
+    await upsert_points_balance(user_id=777002, issuer="KrisFlyer", balance=8200)
+    rows = await query_points_balances(user_id=777002)
+    issuers = {r["issuer"] for r in rows}
+    assert issuers == {"Citibank", "KrisFlyer"}
+
+
+@pytest.mark.asyncio
+async def test_memory_plugin_records_balance(monkeypatch):
+    from orchestrator.router import MemoryPlugin
+
+    fake = AsyncMock(return_value={"balance": 12000.0, "issuer": "DBS", "program": "DBS Rewards"})
+    monkeypatch.setattr("capabilities.memory.tools.extract_points_balance", fake)
+    state = {
+        "user_id": 777003,
+        "messages": [HumanMessage(content="I have 12000 DBS points")],
+    }
+    output = await MemoryPlugin().execute(state)
+    assert "DBS Rewards" in output.message.content
+    assert "12,000" in output.message.content
+
+
+@pytest.mark.asyncio
+async def test_memory_plugin_recall_empty(monkeypatch):
+    from orchestrator.router import MemoryPlugin
+
+    monkeypatch.setattr(
+        "capabilities.memory.tools.query_points_balances",
+        AsyncMock(return_value=[]),
+    )
+    state = {
+        "user_id": 777003,
+        "messages": [HumanMessage(content="what are my points balances?")],
+    }
+    output = await MemoryPlugin().execute(state)
+    assert "don't have any points" in output.message.content
+
+
+def test_deterministic_plan_routes_memory():
+    from orchestrator.planner import deterministic_plan
+
+    state = {
+        "user_id": 1,
+        "active_domain": None,
+        "last_decision": None,
+        "messages": [HumanMessage(content="what are my points balances?")],
+    }
+    decision = deterministic_plan("what are my points balances?", state, None)
+    assert "memory" in decision.capability_ids


### PR DESCRIPTION
## Closes #28

Implements the first slice of personal memory: the agent builds up structured, per-user context over time — starting with **loyalty points/miles balances** (per the issue's recommendation to start narrow and generalize once the pattern proves out).

## Mini-spec (resolves #28's open questions)

| Question | Decision |
|---|---|
| Storage shape | Structured `PointsBalance` table (user_id, issuer, program, balance, expiry_date) — the points/miles domain has explicit fields worth modeling from day one |
| Update semantics | **Upsert by (user_id, issuer, program)** — a new statement for an existing program updates the balance, never appends a duplicate |
| Retrieval | Dedicated `memory` capability: "what are my points balances?"; issuer normalization (CITI→Citibank, POSB→DBS, KrisFlyer, Amex, ...) |
| Generalization path | LLM extraction with deterministic regex fallback; a future slice can widen from points/miles to a general fact-store |

## What it does

- New `memory` capability (manifest + plugin + tools)
- Record: "I have 12000 DBS points expiring next month" → upsert
- Recall: "what are my points balances?" → formatted list with expiry
- Manifest description deliberately avoids generic tokens (e.g. "month") that would steal BM25 rank — verified `expenses` still shortlists on expense queries

## Tests

9 new. Full suite (excluding optional hypothesis fuzz file): **330 passed**. Gauntlet B_acc unchanged from clean main (67/70 — pre-existing `whiteboard` over-planning misses, unrelated).