### PR TITLE
fix(routes): bound RoutePlugin's Maps+LTA journey resolution to stop webhook-level timeout leaks

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -755,6 +755,20 @@ class ExpensePlugin:
         )
 
 
+# Regression (live incident, reported as repeated webhook-level "Still
+# working on that" messages): RoutePlugin.execute() chains multiple external
+# calls -- extract_route_request (LLM, up to LLM_REQUEST_TIMEOUT_SECONDS=30s),
+# then plan_transit_journey's Google Maps Directions call (its own 30s httpx
+# timeout) PLUS one live LTA arrivals lookup per transit leg in the journey
+# (each its own ~15s round-trip, done sequentially, not concurrently) -- with
+# no aggregate bound of its own. Individually-bounded calls whose SUM exceeds
+# the webhook's own 45s ceiling is the exact same bug shape already fixed for
+# whiteboard (#45/PLANNING_INTAKE_TIMEOUT_SECONDS) and GeneralPlugin's tool
+# loop (GENERAL_TOOL_LOOP_TIMEOUT_SECONDS) -- RoutePlugin was the one plugin
+# that never got an equivalent outer bound.
+ROUTE_RESOLUTION_TIMEOUT_SECONDS = 35.0
+
+
 class RoutePlugin:
     """Route capability plugin: plans travel routes and checks real-time Singapore LTA transit alerts."""
 
@@ -766,9 +780,26 @@ class RoutePlugin:
         messages = state.get("messages", [])
         last_text = str(messages[-1].content) if messages else ""
 
+        try:
+            return await asyncio.wait_for(
+                self._resolve(state, messages, last_text),
+                timeout=ROUTE_RESOLUTION_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return PluginOutput(
+                message=AIMessage(content=(
+                    "🚇 Still pulling that route together — Maps/LTA are taking longer than "
+                    "expected. Try asking again in a moment, or be specific: "
+                    "*\"route from Raffles Place to Changi Airport\"*."
+                )),
+                state_update={"active_domain": self.name},
+            )
+
+    async def _resolve(
+        self, state: AssistantState, messages: List[Any], last_text: str
+    ) -> PluginOutput:
         # Bus-arrival queries (times at a stop) use LTA; directions with a
         # destination ("bus from X to Y") go through the Maps journey instead.
-        lowered = last_text.lower()
         from capabilities.routes.tools import (
             handle_bus_query,
             is_bare_place_fragment,

--- a/tests/test_latency_budgets.py
+++ b/tests/test_latency_budgets.py
@@ -133,6 +133,54 @@ async def test_general_plugin_tool_loop_never_exceeds_webhook_budget(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_route_plugin_journey_never_exceeds_webhook_budget(monkeypatch):
+    """RoutePlugin.execute() chains extract_route_request (LLM, individually
+    bounded) into plan_transit_journey, which itself makes a Google Maps
+    Directions call PLUS one live LTA arrivals lookup per transit leg --
+    each individually bounded, but nothing bounded their SUM before this fix
+    (live incident: repeated webhook-level "Still working on that" replies).
+    Mock plan_transit_journey to sleep right at the real aggregate ceiling
+    (Maps ~30s + one LTA leg ~15s = 45s vs the 45s webhook ceiling), scaled
+    down 100x, and confirm the wrapped call still fails fast instead of
+    approaching the webhook's own timeout."""
+    import orchestrator.router as router_module
+    from orchestrator.router import RoutePlugin
+
+    SCALE = 100.0  # real: Maps ~30s + one LTA leg ~15s = 45s vs 45s webhook ceiling
+    monkeypatch.setattr(router_module, "ROUTE_RESOLUTION_TIMEOUT_SECONDS", 35.0 / SCALE)
+
+    async def fake_extract(**kwargs):
+        return {"origin": "Raffles Place", "destination": "Changi Airport", "mode": "transit"}
+
+    async def slow_journey(origin, destination):
+        # Stands in for _directions' own ~30s ceiling PLUS one transit leg's
+        # _live_minutes_for_stop call (~15s) -- individually each fits its
+        # own bound, but their sum (45s) exceeds ROUTE_RESOLUTION_TIMEOUT_SECONDS
+        # (35s), exactly the bug: nothing bounded the sum before this fix.
+        await asyncio.sleep(45.0 / SCALE)
+        return {"error": "should never get here"}
+
+    monkeypatch.setattr(router_module.extract_route_request, "coroutine", fake_extract)
+    monkeypatch.setattr(router_module, "plan_transit_journey", slow_journey)
+
+    plugin = RoutePlugin()
+    state = {
+        "user_id": 9204,
+        "messages": [HumanMessage(content="route from Raffles Place to Changi Airport")],
+    }
+
+    started = time.monotonic()
+    result = await plugin.execute(state)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < WEBHOOK_CEILING_SECONDS / SCALE, (
+        f"route resolution took {elapsed:.2f}s (scaled) -- must fail fast at its own "
+        "bound rather than approach the webhook's own timeout"
+    )
+    assert "taking longer than expected" in result.message.content
+
+
+@pytest.mark.asyncio
 async def test_self_diagnostic_explanation_never_exceeds_webhook_budget(monkeypatch):
     """explain_last_turn() makes one LLM call; SELF_DIAGNOSTIC_TIMEOUT_SECONDS
     wraps it at the plan_dispatch() call site (not inside explain_last_turn


### PR DESCRIPTION
## What

Fixes a live production incident: repeated webhook-level "Still working on that — it's taking longer than expected. Hang tight." replies on route/bus-timing queries.

Confirmed via Railway production logs — two consecutive turns each took ~50s between the `[TG IN]`/`[PLANNER]` log lines and the eventual `POST /api/webhook 200 OK`, exceeding `WEBHOOK_PROCESSING_TIMEOUT_SECONDS=45s`.

## Root cause

`RoutePlugin.execute()` chains `extract_route_request` (LLM call, individually bounded to `LLM_REQUEST_TIMEOUT_SECONDS=30s`) into `plan_transit_journey()`, which itself makes a Google Maps Directions call (its own 30s httpx timeout) **plus one live LTA arrivals lookup per transit leg** in the journey, sequentially — each with its own ~15s round-trip — with **no aggregate bound of its own**.

Individually-bounded calls whose sum exceeds an even-more-outer bound is the exact same latency bug shape already fixed this cycle for whiteboard planning-intake (`PLANNING_INTAKE_TIMEOUT_SECONDS`) and `GeneralPlugin`'s tool loop (`GENERAL_TOOL_LOOP_TIMEOUT_SECONDS`) — `RoutePlugin` was the one plugin that never got an equivalent outer bound, so a slow Maps/LTA response leaked all the way out to the webhook's own generic "hang tight" fallback instead of `RoutePlugin` degrading gracefully on its own.

## Fix

Split `RoutePlugin.execute()` into a thin wrapper and an internal `_resolve()` that does the actual work, wrapped in `asyncio.wait_for(..., timeout=ROUTE_RESOLUTION_TIMEOUT_SECONDS=35.0)` with a graceful route-specific fallback reply on timeout. Covers both the bus-arrival/disambiguation path and the transit-journey/Maps-directions path under one bound, matching the established pattern in this file.

## Testing

- New regression test (`tests/test_latency_budgets.py`) mocks `plan_transit_journey` to sleep right at the real aggregate ceiling (Maps ~30s + one LTA leg ~15s = 45s, scaled down 100x) and confirms the wrapped call now fails fast with a graceful reply instead of approaching the webhook's own timeout — confirmed to fail pre-fix (no `ROUTE_RESOLUTION_TIMEOUT_SECONDS` attribute exists) and pass post-fix.
- Full suite: `uv run pytest -q` → 333 passed, 8 pre-existing failures unrelated to this change (sandbox-restricted env tests + `test_planner`/`test_verify`, unchanged baseline).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_