### PR TITLE
fix(routes): support alternative route requests instead of always returning the same one

### DIFF
--- a/capabilities/routes/journey.py
+++ b/capabilities/routes/journey.py
@@ -39,7 +39,12 @@ async def _directions(origin: str, destination: str) -> dict[str, Any]:
                     "destination": destination,
                     "mode": "transit",
                     "key": settings.google_maps_api_key,
-                    "alternatives": "false",
+                    # Regression: this was hard-coded to "false", so a user
+                    # asking for "other bus"/"a different route" always got
+                    # back the exact same single journey -- there was no
+                    # second option to even offer. plan_transit_journey()
+                    # now picks among data["routes"] via route_index.
+                    "alternatives": "true",
                 },
             )
             data = resp.json()
@@ -81,12 +86,25 @@ async def _live_minutes_for_stop(
     return minutes[0] if minutes else None
 
 
-async def plan_transit_journey(origin: str, destination: str) -> dict[str, Any]:
-    """Full journey: ordered steps, total time, live departures, map link."""
+async def plan_transit_journey(
+    origin: str, destination: str, route_index: int = 0
+) -> dict[str, Any]:
+    """Full journey: ordered steps, total time, live departures, map link.
+
+    route_index selects among Google's alternative routes (0 = the default
+    best route). If route_index is out of range -- the caller asked for
+    "another one" but Maps didn't offer one -- this returns
+    {"error": "no_alternative_available", "route_count": N} rather than
+    silently re-returning route 0, so the caller can be honest about it
+    instead of looking like it ignored the request.
+    """
     data = await _directions(origin, destination)
     if data.get("error"):
         return data
-    leg = data["routes"][0]["legs"][0]
+    routes = data["routes"]
+    if route_index >= len(routes):
+        return {"error": "no_alternative_available", "route_count": len(routes)}
+    leg = routes[route_index]["legs"][0]
     steps: list[dict[str, Any]] = []
     for step in leg.get("steps", []):
         transit = step.get("transit_details") or {}
@@ -137,6 +155,8 @@ async def plan_transit_journey(origin: str, destination: str) -> dict[str, Any]:
         "map_url": MAPS_LINK.format(
             origin=quote(origin), destination=quote(destination)
         ),
+        "route_index": route_index,
+        "route_count": len(routes),
     }
 
 

--- a/capabilities/routes/tools.py
+++ b/capabilities/routes/tools.py
@@ -232,6 +232,26 @@ def is_bare_place_fragment(text: str) -> bool:
     return True
 
 
+def is_alternative_route_request(text: str) -> bool:
+    """True when the user is asking for a different option than the journey
+    just shown ("other bus", "any other route", "something else", "a
+    different way") rather than a fresh place-to-place request.
+
+    Regression: Google Maps Directions was called with alternatives=false,
+    so plan_transit_journey() could only ever return one route -- asking
+    for "other bus" silently got back the exact same journey every time,
+    with no way to even detect the ask. This is the intent classifier that
+    lets RoutePlugin request (and track) the next alternative instead.
+    """
+    lowered = text.strip().lower()
+    if re.search(r"\b(anything|something)\s+else\b", lowered):
+        return True
+    return bool(
+        re.search(r"\b(other|another|different|alternate|alternative)\b", lowered)
+        and re.search(r"\b(bus|buses|route|routes|option|options|way|ways|one|choice|choices)\b", lowered)
+    )
+
+
 def is_bus_disambiguation_answer(
     text: str, pending_stops: Optional[list[Dict[str, Any]]] = None
 ) -> bool:

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -802,6 +802,7 @@ class RoutePlugin:
         # destination ("bus from X to Y") go through the Maps journey instead.
         from capabilities.routes.tools import (
             handle_bus_query,
+            is_alternative_route_request,
             is_bare_place_fragment,
             is_bus_arrival_query,
             is_bus_disambiguation_answer,
@@ -853,7 +854,30 @@ class RoutePlugin:
             )
 
         if mode == "transit":
-            journey = await plan_transit_journey(origin, destination)
+            # Regression: Google Maps was called with alternatives=false, so
+            # "other bus"/"a different route" always got back the exact same
+            # single journey -- there was nothing else to offer. Cycle to
+            # the next Maps alternative when the request is recognizably
+            # asking for one AND it's still the same trip as last time
+            # (otherwise this is a fresh route, start back at index 0).
+            route_index = 0
+            if (
+                is_alternative_route_request(last_text)
+                and last_route.get("origin") == origin
+                and last_route.get("destination") == destination
+            ):
+                route_index = int(last_route.get("route_index") or 0) + 1
+
+            journey = await plan_transit_journey(origin, destination, route_index=route_index)
+            if journey.get("error") == "no_alternative_available":
+                return PluginOutput(
+                    message=AIMessage(content=(
+                        f"🤔 That's actually the only transit route I've got for "
+                        f"*{origin}* → *{destination}* right now — want to try a "
+                        "different starting point or destination?"
+                    )),
+                    state_update={"active_domain": self.name},
+                )
             if not journey.get("error"):
                 return PluginOutput(
                     message=AIMessage(content=format_journey(journey)),
@@ -863,6 +887,7 @@ class RoutePlugin:
                             "origin": origin,
                             "destination": destination,
                             "mode": mode,
+                            "route_index": journey.get("route_index", route_index),
                         },
                     },
                 )

--- a/tests/test_latency_budgets.py
+++ b/tests/test_latency_budgets.py
@@ -152,7 +152,7 @@ async def test_route_plugin_journey_never_exceeds_webhook_budget(monkeypatch):
     async def fake_extract(**kwargs):
         return {"origin": "Raffles Place", "destination": "Changi Airport", "mode": "transit"}
 
-    async def slow_journey(origin, destination):
+    async def slow_journey(origin, destination, route_index=0):
         # Stands in for _directions' own ~30s ceiling PLUS one transit leg's
         # _live_minutes_for_stop call (~15s) -- individually each fits its
         # own bound, but their sum (45s) exceeds ROUTE_RESOLUTION_TIMEOUT_SECONDS

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -317,7 +317,7 @@ async def test_route_plugin_threads_recent_conversation_into_extraction(monkeypa
         captured.update(kwargs)
         return {"origin": "Bugis", "destination": "Changi Airport", "mode": "transit"}
 
-    async def fake_journey(origin, destination):
+    async def fake_journey(origin, destination, route_index=0):
         return {"error": "no live feed"}
 
     async def fake_plan_route(**kwargs):
@@ -348,6 +348,97 @@ async def test_route_plugin_threads_recent_conversation_into_extraction(monkeypa
     assert "recent_context" in captured
     assert "route from Raffles Place to Changi Airport" in captured["recent_context"]
     assert "Bugis" in str(out.message.content)
+
+
+@pytest.mark.asyncio
+async def test_route_plugin_cycles_to_next_alternative_on_request(monkeypatch):
+    """Regression: Google Maps was called with alternatives=false, so
+    "other bus"/"a different route" always got back the exact same single
+    journey (reported live: "It still keeps defaulting to one route").
+    A recognizable "give me another one" ask for the SAME trip as last_route
+    must now advance route_index and pass it through to
+    plan_transit_journey(); a fresh trip (different origin/destination)
+    must NOT inherit the old route_index."""
+    import orchestrator.router as router_module
+    from orchestrator.router import RoutePlugin
+    from langchain_core.messages import AIMessage
+
+    captured_indexes = []
+
+    async def fake_extract(**kwargs):
+        return {"origin": "", "destination": "", "mode": "transit"}
+
+    async def fake_journey(origin, destination, route_index=0):
+        captured_indexes.append(route_index)
+        return {
+            "origin": origin,
+            "destination": destination,
+            "total": f"{20 + route_index} mins",
+            "distance": "10 km",
+            "steps": [],
+            "map_url": "https://maps.example/dir",
+            "route_index": route_index,
+            "route_count": 2,
+        }
+
+    monkeypatch.setattr(router_module.extract_route_request, "coroutine", fake_extract)
+    monkeypatch.setattr(router_module, "plan_transit_journey", fake_journey)
+
+    state = {
+        "messages": [HumanMessage(content="for other bus")],
+        "user_id": 4007,
+        "current_timezone": "UTC",
+        "active_domain": None,
+        "last_route": {"origin": "Raffles Place", "destination": "Changi Airport", "mode": "transit", "route_index": 0},
+    }
+    out = await RoutePlugin().execute(state)
+
+    assert captured_indexes == [1]
+    assert out.state_update["last_route"]["route_index"] == 1
+
+    # A fresh trip (different destination) must reset to index 0, not
+    # inherit the prior route_index just because the phrasing still
+    # matches is_alternative_route_request ("another route").
+    captured_indexes.clear()
+
+    async def fake_extract_fresh(**kwargs):
+        return {"origin": "Bugis", "destination": "Somewhere Else", "mode": "transit"}
+
+    monkeypatch.setattr(router_module.extract_route_request, "coroutine", fake_extract_fresh)
+    state["messages"] = [HumanMessage(content="give me another route from Bugis to somewhere else")]
+    await RoutePlugin().execute(state)
+    assert captured_indexes == [0]
+
+
+@pytest.mark.asyncio
+async def test_route_plugin_is_honest_when_no_alternative_exists(monkeypatch):
+    """When the user asks for another route but Maps only ever offered one,
+    RoutePlugin must say so honestly instead of silently re-sending the
+    same journey (or fabricating a fake alternative)."""
+    import orchestrator.router as router_module
+    from orchestrator.router import RoutePlugin
+    from langchain_core.messages import HumanMessage
+
+    async def fake_extract(**kwargs):
+        return {"origin": "", "destination": "", "mode": "transit"}
+
+    async def fake_journey(origin, destination, route_index=0):
+        return {"error": "no_alternative_available", "route_count": 1}
+
+    monkeypatch.setattr(router_module.extract_route_request, "coroutine", fake_extract)
+    monkeypatch.setattr(router_module, "plan_transit_journey", fake_journey)
+
+    out = await RoutePlugin().execute({
+        "messages": [HumanMessage(content="any other route?")],
+        "user_id": 4008,
+        "current_timezone": "UTC",
+        "active_domain": None,
+        "last_route": {"origin": "Raffles Place", "destination": "Changi Airport", "mode": "transit", "route_index": 0},
+    })
+
+    content = str(out.message.content)
+    assert "only" in content.lower()
+    assert "Raffles Place" in content and "Changi Airport" in content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes a live-reported bug: "It still keeps defaulting to one route why?"

Confirmed via Railway production logs — asking *"For other bus"* after a route was already shown got back the **exact same journey verbatim** ("Fullerton hotel → Tembusu grand"). The planner's own verify step actually caught this ("the reply provided the exact same route as before") and tried re-planning, but had no way to fix it — `RoutePlugin` had no concept of an alternative route at all.

## Root cause

`capabilities/routes/journey.py`'s `_directions()` called the Google Maps Directions API with `alternatives=false`. `plan_transit_journey()` could therefore only ever return exactly one route — there was structurally nothing else to offer, and no code path even detected that the user was asking for one.

## Fix

- `_directions()`: `alternatives=true`, so Maps returns its full route list.
- `plan_transit_journey(origin, destination, route_index=0)`: selects among the available routes; returns `{"error": "no_alternative_available", "route_count": N}` instead of silently re-returning route 0 when the requested index doesn't exist, and includes `route_index`/`route_count` in a successful result.
- `capabilities/routes/tools.py`: new `is_alternative_route_request()` intent classifier ("other bus", "another route", "something else", ...).
- `orchestrator/router.py`'s `RoutePlugin._resolve()`: when the message reads as an alternative request **and** it's the same trip as `last_route` (same origin/destination), advances `route_index` by one and threads it through; persists `route_index` in `last_route` so repeated asks keep cycling through options. A genuinely fresh trip always starts back at index 0. When Maps didn't offer another option, replies honestly instead of repeating the same journey or fabricating a fake one.

## Testing

- Two new regression tests in `tests/test_orchestrator.py`: `route_index` cycling for a same-trip alternative request (plus resetting to 0 for a fresh trip), and the honest no-more-alternatives reply — both confirmed to fail against pre-fix code and pass post-fix.
- Full suite: `uv run pytest -q` → 335 passed, 8 pre-existing failures unrelated to this change (sandbox-restricted env tests + `test_planner`/`test_verify`, unchanged baseline).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_