### PR TITLE
fix(expenses): clamp out-of-range LLM confidence before ExtractedExpense construction

### DIFF
--- a/capabilities/expenses/tools.py
+++ b/capabilities/expenses/tools.py
@@ -22,6 +22,23 @@ from core.tool_guard import identity_bound
 from capabilities.expenses.schemas import ExtractedExpense
 from capabilities.email.tools import apply_gmail_processed_label, apply_email_processed_tag
 
+def _clamp_confidence(raw: Any) -> float:
+    """ExtractedExpense.confidence is constrained to [0.0, 1.0] (schemas.py),
+    but the LLM extraction occasionally returns an out-of-range value (e.g.
+    5.0, apparently scoring confidence out of 5 or 10 instead of as a
+    fraction) -- confirmed live: this crashed log_expenses_from_emails'
+    ExtractedExpense construction uncaught, aborting that user's entire
+    email sweep for the cycle (not just skipping the one bad email), and
+    since the offending email was never marked processed, it re-crashed on
+    every subsequent 10-minute sweep indefinitely. Clamp defensively at
+    every construction site rather than trusting the raw model output."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.9
+    return max(0.0, min(1.0, value))
+
+
 async def is_duplicate_expense(source_message_id: Optional[str]) -> bool:
     """Layer 2 Deduplication: check if source_message_id is in PostgreSQL or was previously deleted."""
     if not source_message_id:
@@ -1249,7 +1266,7 @@ async def log_expenses_from_emails(
             merchant=merchant,
             category=extracted.get("category") or "General",
             date=expense_date,
-            confidence=float(extracted.get("confidence", 0.9)),
+            confidence=_clamp_confidence(extracted.get("confidence", 0.9)),
             needs_clarification=False,
         )
         tx = await save_expense_transaction(
@@ -1338,12 +1355,14 @@ async def process_extracted_expense(
         merchant=merchant,
         category=category,
         date=dt,
-        confidence=confidence,
+        confidence=_clamp_confidence(confidence),
         needs_clarification=needs_clarification,
     )
 
-    # Low confidence or ambiguous: pause execution and request user confirmation
-    if confidence < 0.8 or needs_clarification:
+    # Low confidence or ambiguous: pause execution and request user confirmation.
+    # Uses the clamped value (not the raw param) so an out-of-range model
+    # output can't accidentally dodge this check in either direction.
+    if expense.confidence < 0.8 or needs_clarification:
         hitl_payload = {
             "type": "confirm_action",
             "action": "confirm_expense",

--- a/tests/test_email_and_expenses.py
+++ b/tests/test_email_and_expenses.py
@@ -915,3 +915,85 @@ async def test_multimodal_turn_photo_falls_back_to_caption_expense(monkeypatch):
 
     assert "10.00" in result.content
     assert "Parking" in result.content
+
+
+@pytest.mark.asyncio
+async def test_log_expenses_from_emails_survives_out_of_range_confidence(monkeypatch):
+    """Live production bug (confirmed via Railway logs, present since before
+    this session's rewrite): the LLM extraction occasionally returns a
+    confidence value outside [0.0, 1.0] (e.g. 5.0 -- probably scoring
+    confidence out of 5/10 instead of as a fraction). ExtractedExpense's
+    schema constrains confidence to that range, and log_expenses_from_emails
+    constructed it directly from the raw extracted value with no clamping --
+    the resulting pydantic ValidationError propagated up UNCAUGHT out of the
+    per-email loop, aborting that user's entire sweep for the cycle (not
+    just skipping the one bad email). Because the offending email was never
+    marked processed, the same crash recurred every ~10-minute sweep
+    indefinitely for that user. Confirms _clamp_confidence in
+    capabilities/expenses/tools.py fixes it: fails with the old
+    unclamped `confidence=float(extracted.get("confidence", 0.9))` (raises
+    pydantic.ValidationError), passes once clamped."""
+    from core.models import ExpenseTransaction
+    from capabilities.expenses.tools import extract_expense_from_text, log_expenses_from_emails
+
+    async def fake_extract(**kwargs):
+        return {
+            "amount": 42.0,
+            "currency": "SGD",
+            "merchant": "Test Merchant",
+            "category": "General",
+            "date_iso": "",
+            "confidence": 5.0,  # out of range -- the exact reproduction
+            "needs_clarification": False,
+        }
+
+    monkeypatch.setattr(extract_expense_from_text, "coroutine", fake_extract)
+
+    result = await log_expenses_from_emails.ainvoke({
+        "user_id": 8801,
+        "emails": [{
+            "id": "msg-out-of-range-confidence",
+            "sender": "billing@example.com",
+            "subject": "Your receipt",
+            "body": "You paid $42.00 at Test Merchant.",
+            "date": "",
+        }],
+        "notify": False,
+    })
+
+    assert result["logged"], "the expense should have been logged, not crashed past"
+    assert result["logged"][0]["amount"] == 42.0
+
+    async with async_session_factory() as session:
+        tx = (await session.execute(
+            select(ExpenseTransaction).where(
+                ExpenseTransaction.user_id == 8801,
+                ExpenseTransaction.source_message_id == "msg-out-of-range-confidence",
+            )
+        )).scalar_one()
+    assert tx.amount == 42.0
+
+
+@pytest.mark.asyncio
+async def test_process_extracted_expense_clamps_out_of_range_confidence():
+    """Same guard, on the agent-callable path: the model can pass any
+    confidence value as a tool argument directly (more exposed than the
+    email-sweep path, since there's no upstream code shaping it first).
+    An out-of-range value must clamp to a valid ExtractedExpense.confidence
+    rather than crash process_extracted_expense."""
+    from capabilities.expenses.tools import process_extracted_expense
+
+    result = await process_extracted_expense.ainvoke({
+        "user_id": 8802,
+        "amount": 15.0,
+        "currency": "SGD",
+        "merchant": "Test Merchant",
+        "category": "General",
+        "date_iso": "",
+        "confidence": 5.0,  # out of range
+        "needs_clarification": False,
+        "source_message_id": "test-clamp-process-extracted-expense",
+    })
+    # Clamped to 1.0 (>= 0.8), so this takes the high-confidence silent-save
+    # path rather than pausing on interrupt() -- not a duplicate/HITL status.
+    assert result["status"] == "saved_silently"


### PR DESCRIPTION
## Root cause

Found while checking production logs after PR #66's deploy. `extract_expense_from_text`'s LLM extraction occasionally returns a `confidence` value outside `[0.0, 1.0]` (observed: `5.0`). `ExtractedExpense`'s schema constrains `confidence` to that range, and `log_expenses_from_emails` constructed it directly from the raw extracted value with no clamping — the resulting `pydantic.ValidationError` propagated up **uncaught** out of the per-email loop, aborting that user's *entire* email sweep for the cycle rather than just skipping the one bad email. Because the offending email was never marked processed, the same crash recurred every ~10-minute sweep indefinitely:

```
[SWEEP] error for user 149917165: 1 validation error for ExtractedExpense
confidence
  Input should be less than or equal to 1 [type=less_than_equal, input_value=5.0, ...]
```

Confirmed via Railway logs this has been happening at least since 04:00 UTC today — well before #66's 06:05 UTC deploy — so it's a **pre-existing bug**, not a regression from that rewrite.

## Fix

`capabilities/expenses/tools.py`'s new `_clamp_confidence()` helper, applied at both `ExtractedExpense` construction sites (`log_expenses_from_emails` and `process_extracted_expense`). The latter is actually *more* exposed post-#66 — `confidence` is now a direct agent-callable tool argument there, with no upstream code shaping it first — so this closes the same crash class on that path too, not just the one actually observed in production. `process_extracted_expense`'s HITL threshold check now reads the clamped value for consistency.

## Verification

Regression tests in `tests/test_email_and_expenses.py`, verified against pre-fix code via `git stash`: both raise the exact production `pydantic.ValidationError` on old code, pass once clamped.

```
220 passed, 5 failed
```

The 5 failures are `tests/test_code_sandbox.py::test_c6_probe1-5` — pre-existing, unrelated (same baseline as #66).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_