### PR TITLE
fix(agent_loop): wire admin_only_capabilities into the skill-driven roster

### DIFF
--- a/core/skill_registry.py
+++ b/core/skill_registry.py
@@ -169,7 +169,14 @@ def resolve_skill_tools(skill: Skill) -> List[Any]:
 
 
 def all_declared_tools(skills: Dict[str, Skill]) -> List[Any]:
-    """Every tool declared by any skill, deduplicated, in declaration order."""
+    """Every tool declared by the given (visible) skills, deduplicated, in
+    declaration order.
+
+    ``skills`` may be an admin-filtered subset (see agent_loop's
+    ``_visible_skills``); the undeclared-tool drift warning below therefore
+    compares against the FULL installed skill set, so a gated skill's tools
+    don't produce false "not declared" noise on non-admin turns.
+    """
     registry = build_tool_registry()
     resolved: List[Any] = []
     seen: set[str] = set()
@@ -179,17 +186,20 @@ def all_declared_tools(skills: Dict[str, Skill]) -> List[Any]:
                 continue
             seen.add(tool_obj.name)
             resolved.append(tool_obj)
-    # Guard against registry drift: tools loaded but not declared by any skill
-    # stay available to the agent so a forgotten frontmatter line never
-    # silently removes a capability.
     declared = {t.name for t in resolved}
     internal = {
         "search_email_messages", "search_gmail_messages", "search_outlook_messages",
         "apply_email_processed_tag", "apply_gmail_processed_label", "apply_outlook_processed_category",
         "log_capability_gap",
     }
-    for name, tool_obj in registry.items():
-        if name not in declared and name not in internal:
+    # Compare against the FULL installed skill set, not the visible subset —
+    # a gated skill's tools must not produce false "not declared" noise on
+    # non-admin turns.
+    all_declared: set[str] = set()
+    for skill in discover_skills().values():
+        all_declared.update(skill.tools)
+    for name in registry:
+        if name not in all_declared and name not in internal:
             print(f"[SKILLS] tool {name!r} is registered but not declared by any SKILL.md")
     return resolved
 

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -189,14 +189,36 @@ async def log_capability_gap(tag: str, expectation: str) -> str:
     return await _log_capability_gap({"tag": tag, "expectation": expectation})
 
 
-def _skill_index_text() -> str:
+def _visible_skills(is_admin: bool) -> dict:
+    """Skills this turn's user may see and call.
+
+    ``settings.admin_only_capabilities`` names skills that are hidden from
+    non-admin users entirely — no index entry, no bound tools, no loadable
+    body — so a gated skill's tools never reach a non-admin turn. Admins see
+    everything; with no admin configured (local/dev), every skill is visible.
+    """
+    from core.skill_registry import discover_skills
+
+    skills = discover_skills()
+    if is_admin or not settings.admin_only_capabilities:
+        return skills
+    return {
+        name: skill
+        for name, skill in skills.items()
+        if name not in settings.admin_only_capabilities
+    }
+
+
+def _skill_index_text(visible_skills: dict) -> str:
     """Compact one-line-per-skill index appended to the system prompt."""
-    from core.skill_registry import discover_skills, skill_index_text
+    from core.skill_registry import skill_index_text
 
-    return "\n\n## Skill index\n" + skill_index_text(discover_skills())
+    if not visible_skills:
+        return "\n\n## Skill index\n(none available)"
+    return "\n\n## Skill index\n" + skill_index_text(visible_skills)
 
 
-def _build_tool_roster() -> List[Any]:
+def _build_tool_roster(visible_skills: dict) -> List[Any]:
     """The agent's full tool set, resolved from the installed skills.
 
     Skills are declared in ``skills/<name>/SKILL.md`` (YAML frontmatter: name,
@@ -206,18 +228,21 @@ def _build_tool_roster() -> List[Any]:
     skill = dropping a folder. Late binding is preserved: the registry is
     rebuilt each turn, so tests (and hot skill edits) see fresh modules.
 
-    Sensitive tools (money writes, board writes, ...) remain agent-callable
-    like any other; each guards itself via core.tool_guard.identity_bound.
+    ``visible_skills`` is already filtered by ``_visible_skills`` for admin
+    gating, so tools only a gated skill declares are simply never bound for a
+    non-admin turn. Sensitive tools (money writes, board writes, ...) remain
+    agent-callable like any other; each guards itself via
+    core.tool_guard.identity_bound.
     """
     from core.skill_registry import (
         all_declared_tools,
-        discover_skills,
         make_load_skill_tool,
     )
 
-    skills = discover_skills()
-    tools = all_declared_tools(skills)
-    tools.append(make_load_skill_tool(lambda: discover_skills()))
+    tools = all_declared_tools(visible_skills)
+    tools.append(make_load_skill_tool(lambda: visible_skills))
+    # Loop machinery, not a skill: the agent self-reports capability gaps so
+    # telemetry keeps flowing without a deterministic intent matcher.
     # Loop machinery, not a skill: the agent self-reports capability gaps so
     # telemetry keeps flowing without a deterministic intent matcher.
     tools.append(log_capability_gap)
@@ -558,7 +583,8 @@ async def agent_loop(state: AssistantState) -> Command[str]:
     else:
         pruned = messages
 
-    skill_index = _skill_index_text()
+    visible_skills = _visible_skills(is_admin)
+    skill_index = _skill_index_text(visible_skills)
     history: List[BaseMessage] = [SystemMessage(content=_build_system_prompt(is_admin=is_admin, now=now_sg) + skill_index)]
     for message in pruned:
         if isinstance(message, SystemMessage):
@@ -589,7 +615,7 @@ async def agent_loop(state: AssistantState) -> Command[str]:
             if not has_key:
                 content = _generate_rule_based_response(text)
             else:
-                tools = _build_tool_roster()
+                tools = _build_tool_roster(visible_skills)
                 try:
                     content, extra_messages = await _compose_reply(history, tools, gap_calls)
                     # _run_tool_loop already retries once internally on a

--- a/tests/test_agent_loop_kernel.py
+++ b/tests/test_agent_loop_kernel.py
@@ -56,10 +56,10 @@ async def test_kernel_answers_pending_bus_disambiguation(monkeypatch):
 def test_tool_roster_comes_from_skills():
     """Every tool the agent can call must be declared by a SKILL.md (or be the
     built-in load_skill tool) — the skill files are the declaration surface."""
-    from orchestrator.agent_loop import _build_tool_roster
+    from orchestrator.agent_loop import _build_tool_roster, _visible_skills
     from core.skill_registry import discover_skills
 
-    roster = _build_tool_roster()
+    roster = _build_tool_roster(_visible_skills(True))
     names = {t.name for t in roster}
     assert "load_skill" in names
     declared = set()
@@ -67,3 +67,46 @@ def test_tool_roster_comes_from_skills():
         declared.update(skill.tools)
     undeclared = names - declared - {"load_skill", "log_capability_gap"}
     assert not undeclared, f"roster tools not declared by any skill: {undeclared}"
+
+
+def test_admin_only_capability_gate_hides_code_exec_from_non_admins(monkeypatch):
+    """admin_only_skills (config) must actually gate: a non-admin turn gets no
+    run_python_code tool, no code-exec index entry, and cannot load the skill
+    body — while the admin sees all of it."""
+    from core.config import settings
+    from orchestrator.agent_loop import _build_tool_roster, _skill_index_text, _visible_skills
+
+    monkeypatch.setattr(settings, "admin_telegram_chat_id", "111")
+    monkeypatch.setattr(settings, "admin_only_capabilities", {"code-exec"})
+
+    non_admin_visible = _visible_skills(settings.is_admin(222))
+    assert "code-exec" not in non_admin_visible
+
+    non_admin_roster = _build_tool_roster(non_admin_visible)
+    non_admin_names = {t.name for t in non_admin_roster}
+    assert "run_python_code" not in non_admin_names
+    assert "load_skill" in non_admin_names
+    assert "code-exec" not in _skill_index_text(non_admin_visible)
+
+    load_skill = next(t for t in non_admin_roster if t.name == "load_skill")
+    assert "No skill named" in load_skill.invoke({"name": "code-exec"})
+
+    admin_visible = _visible_skills(settings.is_admin(111))
+    assert "code-exec" in admin_visible
+    admin_names = {t.name for t in _build_tool_roster(admin_visible)}
+    assert "run_python_code" in admin_names
+    assert "code-exec" in _skill_index_text(admin_visible)
+
+
+def test_gate_is_inert_when_no_admin_is_configured(monkeypatch):
+    """With no admin_telegram_chat_id (local/dev), is_admin is True for
+    everyone and the gate must hide nothing."""
+    from core.config import settings
+    from orchestrator.agent_loop import _build_tool_roster, _visible_skills
+
+    monkeypatch.setattr(settings, "admin_telegram_chat_id", None)
+    monkeypatch.setattr(settings, "admin_only_capabilities", {"code-exec"})
+
+    visible = _visible_skills(settings.is_admin(222))
+    assert "code-exec" in visible
+    assert "run_python_code" in {t.name for t in _build_tool_roster(visible)}

--- a/tests/test_general_cross_domain_tools.py
+++ b/tests/test_general_cross_domain_tools.py
@@ -223,9 +223,9 @@ async def test_general_plugin_binds_and_guards_all_cross_domain_tools(monkeypatc
     core.tool_guard.identity_bound path end-to-end via bind_user_id, not an
     introspection shortcut."""
     from core.tool_guard import bind_user_id, current_user_id
-    from orchestrator.agent_loop import _build_tool_roster
+    from orchestrator.agent_loop import _build_tool_roster, _visible_skills
 
-    tools_by_name = {t.name: t for t in _build_tool_roster()}
+    tools_by_name = {t.name: t for t in _build_tool_roster(_visible_skills(True))}
     for tool_name in ("list_my_reminders", "list_my_boards", "summarize_board", "search_my_email"):
         assert tool_name in tools_by_name, f"{tool_name} must be bound in agent_loop's tool roster"
 

--- a/tests/test_general_tools.py
+++ b/tests/test_general_tools.py
@@ -95,8 +95,8 @@ async def test_general_plugin_binds_fetch_url_alongside_search_web():
     """The agent's tool roster must include fetch_url, not just search_web --
     otherwise a user-pasted link still has nowhere to go even though the
     tool exists."""
-    from orchestrator.agent_loop import _build_tool_roster
+    from orchestrator.agent_loop import _build_tool_roster, _visible_skills
 
-    tool_names = {t.name for t in _build_tool_roster()}
+    tool_names = {t.name for t in _build_tool_roster(_visible_skills(True))}
     assert "fetch_url" in tool_names
     assert "search_web" in tool_names


### PR DESCRIPTION
## Problem

`admin_only_capabilities` (config, default `{"code-exec"}`) was **inert** since the agentic-core rewrite: the setting existed but nothing consumed it. `run_python_code` was bound into every turn's tool roster unconditionally, so the multi-tenant gate the config promised was never enforced.

## Fix

- **`_visible_skills(is_admin)`** — one filtered view of the installed skills. Gated skills are hidden from non-admin turns **entirely**: no skill-index entry, no bound tools, and `load_skill` refuses to return their body. One dict drives the index, the roster, and the loader so the three can never drift apart.
- `_build_tool_roster(visible_skills)` / `_skill_index_text(visible_skills)` take the pre-filtered view; `agent_loop` computes it per turn from the trusted `settings.is_admin(user_id)`.
- `all_declared_tools` drift warning now compares against the **full** installed skill set, so a gated skill's tools don't produce false "not declared" noise on non-admin turns.
- With no `admin_telegram_chat_id` configured (local/dev), `is_admin` is True for everyone and the gate hides nothing — unchanged local behavior.

## Tests

2 new: a non-admin loses `run_python_code`/index/`load_skill` while the admin retains all of it; the gate is inert when no admin is configured. Full suite: **230 passed**.