### PR TITLE
fix(agent_loop): carry prior tool results into history; honest blank-reply

### DIFF
--- a/core/skill_registry.py
+++ b/core/skill_registry.py
@@ -190,6 +190,7 @@ def all_declared_tools(skills: Dict[str, Skill]) -> List[Any]:
     internal = {
         "search_email_messages", "search_gmail_messages", "search_outlook_messages",
         "apply_email_processed_tag", "apply_gmail_processed_label", "apply_outlook_processed_category",
+        "extract_expense_from_photo",
         "log_capability_gap",
     }
     # Compare against the FULL installed skill set, not the visible subset —

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -133,7 +133,11 @@ def _build_system_prompt(is_admin: bool, now: str) -> str:
 # it interrupts a conversation the bot was just actively engaged in (reads
 # as total context loss). These stay distinct from that fallback and from
 # each other so each failure mode gets an honest, situation-appropriate reply.
-_EMPTY_REPLY_FALLBACK = "sorry, I didn't quite catch that — could you rephrase or try again?"
+# Regression (live incident, "what other routes"): the model blanked twice
+# in a row and the old fallback told the user to "rephrase" -- but the user's
+# identical re-send worked, so the phrasing was never the problem. The text
+# must own the blank, not imply user error.
+_EMPTY_REPLY_FALLBACK = "🫥 I blanked out for a second there — say that once more?"
 _ERROR_REPLY_FALLBACK = "😵‍💫 sorry, something glitched on my end there — mind trying that again?"
 
 
@@ -586,15 +590,50 @@ async def agent_loop(state: AssistantState) -> Command[str]:
     visible_skills = _visible_skills(is_admin)
     skill_index = _skill_index_text(visible_skills)
     history: List[BaseMessage] = [SystemMessage(content=_build_system_prompt(is_admin=is_admin, now=now_sg) + skill_index)]
-    for message in pruned:
+    # Rebuild provider-facing history WITH prior tool-call provenance: the
+    # #53 feature persists AIMessage(tool_calls) + ToolMessage pairs into
+    # state, but this loop used to drop every ToolMessage -- so follow-ups
+    # like "what other routes" reached the model with zero visibility into
+    # the data its own earlier answer was grounded in. The pairing guard
+    # keeps the provider history well-formed: a tool result whose request
+    # was pruned away (the -10 slice can split a pair) is skipped rather
+    # than sent as an orphan, and an AIMessage whose results were split off
+    # is flattened to content-only.
+    def _tool_ids(message: BaseMessage) -> set:
+        return {
+            str(c.get("id") or c.get("name") or "")
+            for c in (getattr(message, "tool_calls", None) or [])
+        }
+
+    expected_tool_ids: set = set()
+    for idx, message in enumerate(pruned):
         if isinstance(message, SystemMessage):
             history.append(SystemMessage(content=str(message.content)))
         elif isinstance(message, HumanMessage):
+            expected_tool_ids = set()
             history.append(
                 HumanMessage(content=message.content if isinstance(message.content, list) else str(message.content))
             )
         elif isinstance(message, AIMessage):
+            ids = _tool_ids(message)
+            if ids:
+                remaining_ids = {
+                    str(getattr(m, "tool_call_id", "") or "")
+                    for m in pruned[idx + 1:]
+                    if isinstance(m, ToolMessage)
+                }
+                if ids <= remaining_ids:
+                    history.append(message)  # well-formed pair: keep tool_calls
+                    expected_tool_ids = ids
+                    continue
             history.append(AIMessage(content=str(message.content)))
+            expected_tool_ids = set()
+        elif isinstance(message, ToolMessage):
+            tool_id = str(getattr(message, "tool_call_id", "") or "")
+            if tool_id in expected_tool_ids:
+                history.append(message)
+                expected_tool_ids.discard(tool_id)
+            # else: orphaned by pruning -- skip to keep provider history valid
 
     # Trusted, server-resolved identity for this turn -- every identity_bound
     # tool call below (however deep) reads this back, regardless of what a

--- a/tests/test_agent_loop_kernel.py
+++ b/tests/test_agent_loop_kernel.py
@@ -110,3 +110,95 @@ def test_gate_is_inert_when_no_admin_is_configured(monkeypatch):
     visible = _visible_skills(settings.is_admin(222))
     assert "code-exec" in visible
     assert "run_python_code" in {t.name for t in _build_tool_roster(visible)}
+
+
+@pytest.mark.asyncio
+async def test_history_carries_prior_turn_tool_results(monkeypatch):
+    """Regression (live incident, 'what other routes'): the history loop used
+    to drop every ToolMessage, so follow-up asks reached the model with zero
+    visibility into the data its own earlier answer was grounded in. Prior
+    tool-call provenance must reach the model, well-formed."""
+    import orchestrator.agent_loop as al
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    captured = []
+
+    class _CapturingLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            captured.append(list(messages))
+            return AIMessage(content="here's another option: 51 mins via circle line")
+
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _CapturingLLM())
+
+    state = {
+        "user_id": 4242,
+        "current_timezone": "Asia/Singapore",
+        "messages": [
+            HumanMessage(content="route from tembusu grand to fullerton square"),
+            AIMessage(content="", tool_calls=[{
+                "name": "transit_journey",
+                "args": {"origin": "tembusu grand", "destination": "fullerton square"},
+                "id": "call_1",
+                "type": "tool_call",
+            }]),
+            ToolMessage(content="journey data: 40 mins via bus 10", tool_call_id="call_1"),
+            AIMessage(content="best route: 40 mins via bus 10"),
+            HumanMessage(content="what other routes"),
+        ],
+    }
+    result = await al.agent_loop(state)
+    assert "another option" in str(result.update["messages"][-1].content)
+
+    hist = captured[0]
+    assert any(
+        isinstance(m, ToolMessage) and "40 mins via bus 10" in str(m.content) for m in hist
+    ), "prior tool result must reach the model"
+    tool_call_msgs = [m for m in hist if isinstance(m, AIMessage) and m.tool_calls]
+    assert tool_call_msgs, "the paired tool_calls AIMessage must be preserved"
+    assert tool_call_msgs[0].tool_calls[0]["id"] == "call_1"
+    # well-formed: every preserved tool_call is immediately followed by its result
+    for i, m in enumerate(hist):
+        if isinstance(m, AIMessage) and m.tool_calls:
+            assert i + 1 < len(hist) and isinstance(hist[i + 1], ToolMessage)
+
+
+@pytest.mark.asyncio
+async def test_history_skips_orphaned_tool_results(monkeypatch):
+    """A ToolMessage whose request was pruned away (the -10 slice can split a
+    pair) must be skipped, not sent as an orphan — providers reject tool
+    results with no preceding tool_call."""
+    import orchestrator.agent_loop as al
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    captured = []
+
+    class _CapturingLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            captured.append(list(messages))
+            return AIMessage(content="hi there")
+
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _CapturingLLM())
+
+    state = {
+        "user_id": 4242,
+        "current_timezone": "Asia/Singapore",
+        "messages": [
+            ToolMessage(content="orphan result", tool_call_id="call_gone"),
+            AIMessage(content="", tool_calls=[{
+                "name": "transit_journey", "args": {}, "id": "call_split",
+                "type": "tool_call",
+            }]),
+            HumanMessage(content="hi"),
+        ],
+    }
+    await al.agent_loop(state)
+    hist = captured[0]
+    assert not any(isinstance(m, ToolMessage) for m in hist), "orphan tool results must be skipped"
+    # the split-pair AIMessage was flattened to content-only (no dangling tool_calls)
+    assert not any(isinstance(m, AIMessage) and m.tool_calls for m in hist)


### PR DESCRIPTION
## Live incident

Railway production logs: *"what is the best route from tembusu grand to fullerton square"* → good 40-min answer → *"what other routes"* → **"sorry, I didn't quite catch that — could you rephrase or try again?"** → identical re-send → good 51-min answer.

The reply was `_EMPTY_REPLY_FALLBACK`: the model returned empty completions twice (initial + the existing nudge retry). And the user's instinct — *"is there some gap in the context?"* — was exactly right.

## Root cause

The history-building loop **dropped every `ToolMessage`**. State persists `AIMessage(tool_calls)` + `ToolMessage` provenance pairs (#53), but the model never saw them: a follow-up like "what other routes" arrived with zero visibility into the journey data the previous answer was grounded in.

## Fix

1. **History carries well-formed tool pairs** — an `AIMessage` keeps its `tool_calls` only when all its results are present in the remaining window; a `ToolMessage` is appended only when its request preceded it. The prune boundary (`-10` slice) can split a pair, so orphans are skipped and split pairs flattened to content-only (providers reject both malformed shapes).
2. **Honest blank-reply** — `_EMPTY_REPLY_FALLBACK` now owns the blank ("🫥 I blanked out for a second there — say that once more?") instead of implying the user's phrasing was the problem (production proved identical input works).
3. **Log noise** — `extract_expense_from_photo` joins the internal-tool exclusion set (kernel-called by the media handler), killing the every-turn `[SKILLS] not declared` warning in the logs.

## Tests

2 new (prior tool results reach the model as well-formed pairs; orphaned results skipped, split pairs flattened). Full suite: **232 passed**.