### PR TITLE
fix(agent_loop): flatten a tool-call AIMessage that opens the pruned window

### DIFF
--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -599,6 +599,23 @@ async def agent_loop(state: AssistantState) -> Command[str]:
     # was pruned away (the -10 slice can split a pair) is skipped rather
     # than sent as an orphan, and an AIMessage whose results were split off
     # is flattened to content-only.
+    #
+    # Regression (live incident, chat=149917165, "Coffee at hive ..."):
+    # Gemini rejected the very first call of the turn with 400 INVALID_ARGUMENT
+    # "function call turn comes immediately after a user turn or after a
+    # function response turn." Root cause -- the -10 prune window can start
+    # mid-pair, landing an AIMessage(tool_calls) as the FIRST substantive
+    # message in the rebuilt window, with no HumanMessage/ToolMessage turn
+    # in front of it at all (the old check only verified its ToolMessage
+    # pair existed somewhere *later*, never that a valid anchor turn came
+    # *before* it -- SystemMessages don't count, langchain_google_genai
+    # merges every non-first one into system_instruction and drops it from
+    # the turn sequence entirely, so a tool-calling AIMessage right after
+    # one is effectively the conversation's opening turn). Preserve
+    # tool_calls only when the turn immediately preceding it in the
+    # rebuilt history is itself a human/tool turn -- exactly Gemini's own
+    # rule -- otherwise flatten to content-only, same as any other
+    # malformed pair.
     def _tool_ids(message: BaseMessage) -> set:
         return {
             str(c.get("id") or c.get("name") or "")
@@ -606,17 +623,21 @@ async def agent_loop(state: AssistantState) -> Command[str]:
         }
 
     expected_tool_ids: set = set()
+    last_turn_kind: str | None = None  # "human" | "tool" | "ai" | "ai_tc" | None
     for idx, message in enumerate(pruned):
         if isinstance(message, SystemMessage):
             history.append(SystemMessage(content=str(message.content)))
+            # Not a turn a provider ever sees (see comment above) -- doesn't
+            # change what the *next* message can safely anchor against.
         elif isinstance(message, HumanMessage):
             expected_tool_ids = set()
             history.append(
                 HumanMessage(content=message.content if isinstance(message.content, list) else str(message.content))
             )
+            last_turn_kind = "human"
         elif isinstance(message, AIMessage):
             ids = _tool_ids(message)
-            if ids:
+            if ids and last_turn_kind in ("human", "tool"):
                 remaining_ids = {
                     str(getattr(m, "tool_call_id", "") or "")
                     for m in pruned[idx + 1:]
@@ -625,14 +646,17 @@ async def agent_loop(state: AssistantState) -> Command[str]:
                 if ids <= remaining_ids:
                     history.append(message)  # well-formed pair: keep tool_calls
                     expected_tool_ids = ids
+                    last_turn_kind = "ai_tc"
                     continue
             history.append(AIMessage(content=str(message.content)))
             expected_tool_ids = set()
+            last_turn_kind = "ai"
         elif isinstance(message, ToolMessage):
             tool_id = str(getattr(message, "tool_call_id", "") or "")
             if tool_id in expected_tool_ids:
                 history.append(message)
                 expected_tool_ids.discard(tool_id)
+                last_turn_kind = "tool"
             # else: orphaned by pruning -- skip to keep provider history valid
 
     # Trusted, server-resolved identity for this turn -- every identity_bound

--- a/tests/test_agent_loop_kernel.py
+++ b/tests/test_agent_loop_kernel.py
@@ -202,3 +202,68 @@ async def test_history_skips_orphaned_tool_results(monkeypatch):
     assert not any(isinstance(m, ToolMessage) for m in hist), "orphan tool results must be skipped"
     # the split-pair AIMessage was flattened to content-only (no dangling tool_calls)
     assert not any(isinstance(m, AIMessage) and m.tool_calls for m in hist)
+
+
+@pytest.mark.asyncio
+async def test_history_flattens_a_tool_call_that_opens_the_pruned_window(monkeypatch):
+    """Live incident (chat=149917165, 'Coffee at hive Adelphi Samuel paid me
+    5.50...'): Gemini rejected the very first model call of the turn with
+    400 INVALID_ARGUMENT, 'Please ensure that function call turn comes
+    immediately after a user turn or after a function response turn.'
+
+    Root cause: the -10 prune window can start mid-pair, landing an
+    AIMessage(tool_calls) as the first substantive message in the rebuilt
+    window -- the old pairing check only verified its ToolMessage result
+    existed *later* in the window, never that a valid user/tool anchor turn
+    came *before* it. SystemMessages (the pruning summary note included)
+    don't count as an anchor: langchain_google_genai merges every
+    non-first SystemMessage into system_instruction and drops it from the
+    turn sequence entirely, so a tool-calling AIMessage placed right after
+    one is effectively the opening turn of the conversation -- exactly the
+    shape Gemini's API rejects."""
+    import orchestrator.agent_loop as al
+    from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+
+    captured = []
+
+    class _CapturingLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            captured.append(list(messages))
+            return AIMessage(content="ok")
+
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _CapturingLLM())
+    monkeypatch.setattr(al.settings, "gemini_api_key", "fake-key-for-test")
+
+    # 14 messages (> prune_and_summarize_messages' threshold=12) so the -10
+    # window kicks in and starts exactly at the tool-calling AIMessage below,
+    # cutting off its originating HumanMessage.
+    messages = [
+        HumanMessage(content="h0"), AIMessage(content="a0"),
+        HumanMessage(content="h1"), AIMessage(content="a1"),
+        AIMessage(content="", tool_calls=[{
+            "name": "get_bus_timings", "args": {}, "id": "c1", "type": "tool_call",
+        }]),  # position -10: first element of the pruned window
+        ToolMessage(content="tool result data", tool_call_id="c1"),
+        AIMessage(content="final answer using tool result"),
+        HumanMessage(content="h2"), AIMessage(content="a2"),
+        HumanMessage(content="h3"), AIMessage(content="a3"),
+        HumanMessage(content="h4"), AIMessage(content="a4"),
+        HumanMessage(content="h5 current"),
+    ]
+    state = {"user_id": 4242, "current_timezone": "Asia/Singapore", "messages": messages}
+    await al.agent_loop(state)
+
+    hist = captured[0]
+    turns = [m for m in hist if not isinstance(m, SystemMessage)]
+    assert turns, "some real turn must survive pruning"
+    assert isinstance(turns[0], AIMessage) and not turns[0].tool_calls, (
+        "the window-opening AIMessage must be flattened to content-only -- "
+        "sending it with tool_calls as the provider-facing history's "
+        "opening turn is exactly what Gemini's API rejected live"
+    )
+    # its orphaned-by-flattening ToolMessage pair must not be sent either --
+    # a tool result with no preceding tool_calls is equally invalid.
+    assert not any(isinstance(m, ToolMessage) and m.tool_call_id == "c1" for m in hist)


### PR DESCRIPTION
## Root cause

Live incident, confirmed via Railway production logs (chat=149917165, 2026-08-28 02:01:56 UTC):

```
[TG IN] chat=149917165: Coffee at hive Adelphi Samuel paid me 5.50 because I paid first
[AGENT_LOOP] tool loop failed, using fallback: Error calling model 'gemini-2.5-flash' (INVALID_ARGUMENT): 400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Please ensure that function call turn comes immediately after a user turn or after a function response turn.', 'status': 'INVALID_ARGUMENT'}}
```

This failed on the turn's very first model call — before any retries or tool rounds — so the malformed data had to already be in the provider-facing history built from persisted state.

`prune_and_summarize_messages`'s `-10` window can start mid-pair, landing an `AIMessage(tool_calls)` as the first substantive message in the rebuilt history. The pairing guard added in #71 only checked that the AIMessage's `ToolMessage` result existed *later* in the window — it never checked that a valid anchor turn came *before* it. A `SystemMessage` doesn't count as that anchor: `langchain_google_genai`'s `_parse_chat_history` merges every non-first `SystemMessage` into `system_instruction` and drops it from the turn sequence entirely — confirmed by reading that function directly. So a tool-calling `AIMessage` placed right after one (which the pruning summary note always is) becomes, from Gemini's point of view, the *opening* turn of the conversation. Reproduced locally with a standalone repro script against the real message-conversion logic before writing the fix.

## Fix

`orchestrator/agent_loop.py`'s history rebuild now tracks the kind of turn last appended (human/tool/ai/ai_tc). An `AIMessage` keeps its `tool_calls` only when **both** hold: its results are present later in the window (existing check), and the immediately preceding turn is itself human or tool (new check) — exactly Gemini's own rule. Otherwise it's flattened to content-only, same handling already used for any other malformed pair.

## Tests

New regression test in `tests/test_agent_loop_kernel.py`: a 14-message history pruned to a window that opens exactly on the tool-calling `AIMessage` must have it sent as content-only, with its now-orphaned `ToolMessage` pair dropped. Confirmed failing against pre-fix code via `git stash`, passing post-fix.

Full suite: 226 passed. 7 pre-existing failures unrelated to this change — 5 sandbox-restricted-env tests (`test_code_sandbox.py`) and 2 `test_agent_loop_kernel.py` tests (added in #71) that need a live `GEMINI_API_KEY` to reach their mocked-LLM path; confirmed both fail identically on vanilla `main` in this environment.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_