### PR TITLE
fix(agent_loop): hard-bound every model call, independent of the client's own timeout

### DIFF
--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -24,6 +24,7 @@ than being kept out of the agent's reach or special-cased here.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from datetime import datetime
 from typing import Any, List
@@ -44,7 +45,7 @@ from langgraph.types import Command
 from core.audit import log_capability_request, perform_conversation_audit, should_audit_conversation
 from core.background import fire_and_forget
 from core.config import settings
-from core.llm import ThinkingLevel, extract_llm_text, get_agent_llm, get_multimodal_llm
+from core.llm import LLM_REQUEST_TIMEOUT_SECONDS, ThinkingLevel, extract_llm_text, get_agent_llm, get_multimodal_llm
 from core.tool_guard import bind_user_id, current_user_id
 from orchestrator.checkpointer import prune_and_summarize_messages, recent_turns
 from orchestrator.state import AssistantState
@@ -60,6 +61,36 @@ URL_PATTERN = re.compile(r"https?://\S+")
 # truly broken loop (a tool whose result always makes the model want to call
 # it again); a real multi-step request should never come remotely close.
 MAX_TOOL_ROUNDS = 40
+
+# Belt-and-suspenders backstop for a single model call -- NOT another
+# disguised wall-clock ceiling on the turn (that stays MAX_TOOL_ROUNDS'
+# job, unbounded per the docstring above). core/llm.py already configures
+# timeout=LLM_REQUEST_TIMEOUT_SECONDS on every LLM client constructor, but
+# live evidence (round-by-round tracing in _run_tool_loop below,
+# chat=149917165) showed a model call hang for 6+ minutes with that
+# client-level timeout never firing: "round 1: awaiting model completion"
+# printed, then total silence -- no TimeoutError, no reply, nothing.
+# Wrapping every ainvoke() here in an explicit asyncio.wait_for is a second,
+# independent enforcement of the same bound regardless of why the client's
+# own timeout didn't fire for that call. Padded above the client's own
+# timeout so the client's own (more specific) error has first chance to
+# fire; this is the fallback for when it doesn't.
+_MODEL_CALL_TIMEOUT_SECONDS = LLM_REQUEST_TIMEOUT_SECONDS + 15.0
+
+
+async def _invoke_model(llm: Any, messages: List[BaseMessage]) -> AIMessage:
+    """await llm.ainvoke(messages), hard-bounded so a stuck call surfaces as
+    a normal catchable exception (feeding the existing honest-error
+    fallback) instead of hanging the turn -- and the whole process, since
+    this always runs inside a fire-and-forget background task -- forever."""
+    try:
+        return await asyncio.wait_for(llm.ainvoke(messages), timeout=_MODEL_CALL_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(
+            f"model call did not return within {_MODEL_CALL_TIMEOUT_SECONDS:.0f}s "
+            "(client-level timeout did not fire)"
+        ) from exc
+
 
 # Old GuardrailPolicy's tag vocabulary (orchestrator/router.py, deleted) --
 # kept only as illustrative examples in the system prompt, not as a matcher:
@@ -303,7 +334,7 @@ async def _handle_multimodal_turn(
             )
         try:
             llm = get_multimodal_llm(temperature=0.2)
-            ai_message = await llm.ainvoke(history)
+            ai_message = await _invoke_model(llm, history)
             content = extract_llm_text(getattr(ai_message, "content", "")).strip()
             content = content or "I processed your media message, but couldn't generate a description."
         except Exception as exc:  # noqa: BLE001
@@ -399,7 +430,7 @@ async def _run_tool_loop(hist: List[BaseMessage], tools: List[Any], gap_calls: l
     # if a turn does go silent, Railway logs show exactly which round and
     # which call it was last seen entering instead of nothing at all.
     print("[AGENT_LOOP] round 0: awaiting model completion")
-    ai_message = await llm_with_tools.ainvoke(hist)
+    ai_message = await _invoke_model(llm_with_tools, hist)
     for _round in range(MAX_TOOL_ROUNDS):
         tool_calls = getattr(ai_message, "tool_calls", None) or []
         if not tool_calls:
@@ -432,7 +463,7 @@ async def _run_tool_loop(hist: List[BaseMessage], tools: List[Any], gap_calls: l
                 ToolMessage(content=str(observation), tool_call_id=str(call.get("id") or call_name))
             )
         print(f"[AGENT_LOOP] round {_round + 1}: awaiting model completion")
-        ai_message = await llm_with_tools.ainvoke(hist)
+        ai_message = await _invoke_model(llm_with_tools, hist)
 
     text = extract_llm_text(getattr(ai_message, "content", "")).strip()
     round_budget_exhausted = False
@@ -446,7 +477,7 @@ async def _run_tool_loop(hist: List[BaseMessage], tools: List[Any], gap_calls: l
                     tool_call_id=str(call.get("id") or call.get("name") or ""),
                 )
             )
-        final_message = await llm_with_tools.ainvoke(hist)
+        final_message = await _invoke_model(llm_with_tools, hist)
         text = extract_llm_text(getattr(final_message, "content", "")).strip()
 
     # Regression (live incident): mid-conversation, the model sometimes
@@ -472,7 +503,7 @@ async def _run_tool_loop(hist: List[BaseMessage], tools: List[Any], gap_calls: l
                 )
             )
         )
-        retry_message = await llm_with_tools.ainvoke(hist)
+        retry_message = await _invoke_model(llm_with_tools, hist)
         text = extract_llm_text(getattr(retry_message, "content", "")).strip()
         if not text and getattr(retry_message, "tool_calls", None):
             # The retry decided it needs a tool after all -- let the caller
@@ -499,7 +530,7 @@ async def _run_tool_loop(hist: List[BaseMessage], tools: List[Any], gap_calls: l
                 hist.append(
                     ToolMessage(content=str(observation), tool_call_id=str(call.get("id") or call_name))
                 )
-            final_retry_message = await llm_with_tools.ainvoke(hist)
+            final_retry_message = await _invoke_model(llm_with_tools, hist)
             text = extract_llm_text(getattr(final_retry_message, "content", "")).strip()
     return text, link_tool_used
 

--- a/tests/test_agent_loop_model_call_timeout.py
+++ b/tests/test_agent_loop_model_call_timeout.py
@@ -1,0 +1,54 @@
+"""Live incident (chat=149917165, "Coffee at hive Adelphi Samuel paid me
+5.50..."): round-by-round tracing added to _run_tool_loop caught a model
+call hanging forever -- "[AGENT_LOOP] round 1: awaiting model completion"
+printed, then total silence for 6+ minutes straight, no TimeoutError, no
+reply, nothing -- despite core/llm.py already configuring
+timeout=LLM_REQUEST_TIMEOUT_SECONDS on every LLM client. Whatever the
+client-level timeout's blind spot is, a turn must never be able to hang
+the whole (fire-and-forget, per app/webhook.py) background task forever.
+
+Fix: orchestrator/agent_loop.py's _invoke_model wraps every llm.ainvoke()
+call in an explicit asyncio.wait_for, independent of the client's own
+timeout config -- a stuck call now surfaces as a normal TimeoutError
+instead of hanging, and the existing honest-error fallback takes it from
+there exactly like any other tool-loop exception."""
+import asyncio
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from orchestrator.agent_loop import _ERROR_REPLY_FALLBACK, agent_loop
+
+
+class _HangsForeverLLM:
+    """Reproduces the exact live shape: bind_tools().ainvoke() never
+    returns and never raises on its own -- the client-level timeout that's
+    supposed to guard against exactly this simply didn't fire."""
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        await asyncio.Event().wait()  # never set -- hangs forever
+        return AIMessage(content="unreachable")
+
+
+@pytest.mark.asyncio
+async def test_a_hung_model_call_times_out_instead_of_hanging_the_turn_forever(monkeypatch):
+    import orchestrator.agent_loop as agent_loop_module
+
+    # Real timeout mechanics, just fast enough for a test.
+    monkeypatch.setattr(agent_loop_module, "_MODEL_CALL_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(agent_loop_module, "get_agent_llm", lambda *a, **k: _HangsForeverLLM())
+    monkeypatch.setattr(agent_loop_module.settings, "gemini_api_key", "fake-key-for-test")
+
+    command = await asyncio.wait_for(
+        agent_loop({
+            "user_id": 149917165,
+            "messages": [HumanMessage(content="Coffee at hive Adelphi Samuel paid me 5.50 because I paid first")],
+        }),
+        timeout=5.0,  # the test's own outer bound -- must never actually be needed
+    )
+
+    reply = str(command.update["messages"][-1].content)
+    assert reply == _ERROR_REPLY_FALLBACK


### PR DESCRIPTION
## Context

Follow-up to #72/#73. After #73 deployed (fire-and-forget task tracking + round-by-round tracing), the user retried the exact same message and it *still* silently ate the reply. But this time the new tracing pinpointed exactly where, live in production (deployment `f1e1bc89`):

```
[AGENT_LOOP] round 0: awaiting model completion
[AGENT_LOOP] round 0: calling tool record_incoming_money
[AGENT_LOOP] round 0: tool record_incoming_money returned
[AGENT_LOOP] round 1: awaiting model completion
<nothing -- 6+ minutes straight, no TimeoutError, no reply, nothing>
```

The tool ran fine and returned a normal short string. The **second** model call (history now includes the tool result) just never returns and never raises — despite `core/llm.py` already configuring `timeout=LLM_REQUEST_TIMEOUT_SECONDS=30.0` on every LLM client constructor.

## Fix

`orchestrator/agent_loop.py`'s new `_invoke_model()` wraps every `llm.ainvoke()` call (all 6 call sites) in an explicit `asyncio.wait_for` — a second, independent enforcement of the same bound regardless of why the client's own timeout doesn't always fire. Padded 15s above the client's configured timeout so the client's own (more specific) error gets first chance to fire; this is the fallback for when it doesn't. Scoped to one model call, not the whole turn — `MAX_TOOL_ROUNDS` stays the only bound on turn length, per this repo's existing "no wall-clock ceiling on the agent" design.

A stuck call now surfaces as a plain `TimeoutError`, caught by `agent_loop`'s existing broad `except` exactly like any other tool-loop exception, producing the honest `_ERROR_REPLY_FALLBACK` instead of silence.

## Honesty note

This bounds the *symptom* (a hung call can no longer hang the turn forever) rather than a fully root-caused fix for *why* the client-level timeout didn't fire for this specific call — that would need live process access (a debugger/profiler on the running container) this environment doesn't have. Flagging that directly, not overclaiming certainty.

## Tests

`tests/test_agent_loop_model_call_timeout.py` reproduces the exact shape (a fake LLM whose `ainvoke()` hangs forever) with the timeout monkeypatched to 50ms for speed; confirms `agent_loop` returns the honest fallback well within a 5s outer bound instead of hanging. Confirmed failing pre-fix (`AttributeError`), passing post-fix (0.19s in isolation).

Full suite: 229 passed. Same 7 pre-existing failures as #72/#73 — confirmed unrelated.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_