### PR TITLE
fix: root-cause the silent-reply incident — three defects, all confirmed live

### DIFF
--- a/app/ingress.py
+++ b/app/ingress.py
@@ -232,6 +232,10 @@ async def send_telegram_chat_action(chat_id: int, action: str = "typing") -> boo
     )
 
 
+# How long a new message for a chat waits for an in-flight turn before telling
+# the user it is still busy, instead of queueing behind it in silence.
+CHAT_LOCK_WAIT_SECONDS = 90.0
+
 class TelegramIngress:
     """Deep ingress adapter for Telegram Bot API payloads, slash commands, callbacks, and profile lookup."""
 
@@ -1273,8 +1277,37 @@ class TelegramIngress:
                 "active_domain": None,
             }
 
-            async with self._lock_for_chat(chat_id):
+            # Serialize this chat's graph invocations -- but never queue
+            # behind a wedged one forever.
+            #
+            # Live incident (chat=149917165): a turn hung inside its model
+            # call while holding this lock, and the user's NEXT message
+            # ("Hello") produced no agent-loop output at all -- it was still
+            # waiting here. One stuck turn silently killed the entire chat,
+            # which is what made the bug look like "the bot is dead" rather
+            # than "one message failed".
+            #
+            # The turn itself stays deliberately unbounded (see
+            # agent_loop.MAX_TOOL_ROUNDS -- "time should not limit the
+            # agent"); what is bounded is how long a NEW message waits for
+            # its turn before saying so out loud. asyncio.wait_for is the
+            # right tool for exactly this one: asyncio.Lock.acquire is stdlib
+            # and honours cancellation cleanly, unlike the third-party client
+            # code that needs core.tool_safety.bounded_call.
+            lock = self._lock_for_chat(chat_id)
+            try:
+                await asyncio.wait_for(lock.acquire(), timeout=CHAT_LOCK_WAIT_SECONDS)
+            except asyncio.TimeoutError:
+                await send_telegram_message(
+                    chat_id,
+                    "⏳ I'm still working on your previous message — give me a moment "
+                    "and send that again.",
+                )
+                return {"status": "ok", "processed": False, "reason": "chat_busy"}
+            try:
                 result = await get_assistant_graph().ainvoke(initial_state, config=config)
+            finally:
+                lock.release()
             interrupts = result.get("__interrupt__")
             if interrupts:
                 for interrupt_item in interrupts:

--- a/core/llm.py
+++ b/core/llm.py
@@ -16,6 +16,14 @@ logger = logging.getLogger("nexus_prime.llm")
 # forever -- piling up duplicate in-flight work for one stuck chat.
 LLM_REQUEST_TIMEOUT_SECONDS = 30.0
 
+# The Gemini client retries internally SIX times by default. With a 30s
+# per-attempt timeout that is a ~3min worst case hidden inside a single
+# ainvoke(), far longer than any bound the caller thinks it has -- and each
+# retry is another chance to swallow an outer cancellation (see
+# core.tool_safety.bounded_call, and the silent-reply incident it documents).
+# 2 = the initial request plus one genuine retry for a transient blip.
+LLM_MAX_RETRIES = 2
+
 class ThinkingLevel(str, Enum):
     """
     Thinking complexity tiers for DeepSeek v4 Flash agent reasoning.
@@ -65,6 +73,7 @@ def get_llm(
             google_api_key=api_key,
             temperature=temperature,
             timeout=LLM_REQUEST_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
         )
 
     elif role == "agent_core":
@@ -76,6 +85,7 @@ def get_llm(
                 google_api_key=api_key,
                 temperature=temperature,
                 timeout=LLM_REQUEST_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
             )
 
         api_key = settings.deepseek_api_key or "test_deepseek_key"
@@ -101,6 +111,7 @@ def get_llm(
             reasoning_effort=thinking_config["reasoning_effort"],
             max_tokens=thinking_config["max_tokens"],
             timeout=LLM_REQUEST_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
         )
 
     else:
@@ -121,6 +132,7 @@ def get_judge_llm(temperature: float = 0.0) -> ChatGoogleGenerativeAI:
         google_api_key=api_key,
         temperature=temperature,
         timeout=LLM_REQUEST_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
     )
 
 def get_agent_llm(

--- a/core/tool_guard.py
+++ b/core/tool_guard.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextvars
 import functools
+import inspect
 from typing import Awaitable, Callable, Optional, TypeVar
 
 # Unset (None) outside of an agent-loop turn -- e.g. core/scheduler.py's
@@ -70,5 +71,46 @@ def identity_bound(fn: F) -> F:
         if bound is not None:
             kwargs["user_id"] = int(bound)
         return await fn(*args, **kwargs)
+
+    # Advertise `user_id` to schema generation as OPTIONAL, whatever the real
+    # function declares.
+    #
+    # Live incident (chat=149917165, "What are my recent expenses" ->
+    # get_user_expenses -> invalid_args): @tool builds its args_schema by
+    # inspecting the function it wraps, and LangChain validates the model's
+    # arguments against that schema BEFORE the function -- and therefore
+    # before this wrapper -- ever runs. Every one of these tools documents
+    # `user_id` as "ignored; the assistant injects the authenticated user's
+    # ID", so the model correctly omits it... and on the 12 tools that
+    # declared a bare `user_id: int` with no default, pydantic rejected the
+    # call outright with "Field required". get_user_expenses,
+    # process_extracted_expense, split_bill_expense and all of email search
+    # were unreachable whenever the model followed its own instructions.
+    # (The 19 tools that happened to write `user_id: int = 0` worked purely
+    # by accident of that default.)
+    #
+    # Patching __signature__ here fixes all of them at once, and keeps new
+    # tools correct by construction rather than relying on every author
+    # remembering the `= 0`. Runtime binding is unaffected: the wrapper takes
+    # *args/**kwargs and forwards to the real function, so __signature__ is
+    # metadata read by schema generation only. Security is unchanged -- the
+    # override above is still unconditional, so a model-supplied user_id is
+    # discarded exactly as before (verified: a forged id is still replaced).
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return wrapper  # type: ignore[return-value]
+
+    if "user_id" in signature.parameters:
+        others = [p for name, p in signature.parameters.items() if name != "user_id"]
+        # Moved last and keyword-only: a defaulted parameter may not precede a
+        # required one, and every caller of a @tool passes arguments by name.
+        user_id_param = signature.parameters["user_id"].replace(
+            default=0, kind=inspect.Parameter.KEYWORD_ONLY
+        )
+        try:
+            wrapper.__signature__ = signature.replace(parameters=others + [user_id_param])
+        except ValueError:  # pragma: no cover - e.g. an existing **kwargs tail
+            pass
 
     return wrapper  # type: ignore[return-value]

--- a/core/tool_safety.py
+++ b/core/tool_safety.py
@@ -71,6 +71,35 @@ TOOL_CALL_TIMEOUT_SECONDS = 120.0
 MAX_REPEATED_FAILURES = 2
 
 
+async def bounded_call(coro, timeout: float, what: str):
+    """Await ``coro``, giving up after ``timeout`` EVEN IF it refuses to die.
+
+    asyncio.wait_for is not sufficient, and this is not theoretical -- it is
+    the root cause of the silent-reply incident. wait_for cancels the inner
+    task and then *awaits* that cancellation; a task that swallows
+    CancelledError therefore hangs wait_for forever, past its own timeout.
+    Reproduced directly: a coroutine looping `except CancelledError: continue`
+    hung wait_for indefinitely, and even an OUTER wait_for around it could not
+    break the deadlock.
+
+    That is exactly the shape of a retrying HTTP/gRPC client (the Gemini SDK
+    defaults to 6 internal retries), which is why PR #74's wait_for-based
+    bound never fired in production despite being deployed and correct-looking.
+
+    So: run it as a task, wait on the task, and on timeout cancel it
+    best-effort and ABANDON it -- never await the cancellation. The orphaned
+    task may linger until its own client-level timeout resolves it, which is
+    the deliberate trade: a leaked task is survivable, a wedged turn is not
+    (it holds the per-chat lock and silently swallows every later message).
+    """
+    task = asyncio.ensure_future(coro)
+    _done, pending = await asyncio.wait({task}, timeout=timeout)
+    if task in pending:
+        task.cancel()  # best effort; deliberately NOT awaited
+        raise TimeoutError(f"{what} did not complete within {timeout:.0f}s (abandoned)")
+    return task.result()
+
+
 @dataclass
 class ToolOutcome:
     """Structured result of one tool invocation.
@@ -199,14 +228,14 @@ async def execute_tool_safely(
         )
 
     try:
-        result = await asyncio.wait_for(tool_obj.ainvoke(args), timeout=timeout)
+        result = await bounded_call(tool_obj.ainvoke(args), timeout, f"tool {tool_name}")
         return ToolOutcome("success", str(result))
 
     except GraphBubbleUp:
         # interrupt() / Command routing -- must reach the graph runtime.
         raise
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         if ledger is not None:
             ledger.record_failure(tool_name, args)
         return ToolOutcome(

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -47,7 +47,7 @@ from core.background import fire_and_forget
 from core.config import settings
 from core.llm import LLM_REQUEST_TIMEOUT_SECONDS, ThinkingLevel, extract_llm_text, get_agent_llm, get_multimodal_llm
 from core.tool_guard import bind_user_id, current_user_id
-from core.tool_safety import FailureLedger, ToolOutcome, execute_tool_safely
+from core.tool_safety import FailureLedger, ToolOutcome, bounded_call, execute_tool_safely
 from orchestrator.checkpointer import prune_and_summarize_messages, recent_turns
 from orchestrator.state import AssistantState
 
@@ -63,19 +63,21 @@ URL_PATTERN = re.compile(r"https?://\S+")
 # it again); a real multi-step request should never come remotely close.
 MAX_TOOL_ROUNDS = 40
 
-# Belt-and-suspenders backstop for a single model call -- NOT another
-# disguised wall-clock ceiling on the turn (that stays MAX_TOOL_ROUNDS'
-# job, unbounded per the docstring above). core/llm.py already configures
-# timeout=LLM_REQUEST_TIMEOUT_SECONDS on every LLM client constructor, but
-# live evidence (round-by-round tracing in _run_tool_loop below,
-# chat=149917165) showed a model call hang for 6+ minutes with that
-# client-level timeout never firing: "round 1: awaiting model completion"
-# printed, then total silence -- no TimeoutError, no reply, nothing.
-# Wrapping every ainvoke() here in an explicit asyncio.wait_for is a second,
-# independent enforcement of the same bound regardless of why the client's
-# own timeout didn't fire for that call. Padded above the client's own
-# timeout so the client's own (more specific) error has first chance to
-# fire; this is the fallback for when it doesn't.
+# Backstop for a single model call -- NOT another disguised wall-clock
+# ceiling on the turn (that stays MAX_TOOL_ROUNDS' job, unbounded per the
+# docstring above). Padded above core/llm.py's own client-level timeout so
+# the client's more specific error gets first chance to fire.
+#
+# Two earlier attempts at this bound did NOT work, and the reasons matter:
+#   1. core/llm.py's timeout= on the client. Never surfaced, because the
+#      Gemini SDK retried internally 6 times by default (now capped, see
+#      LLM_MAX_RETRIES) -- a ~3min worst case hidden inside one ainvoke().
+#   2. PR #74's asyncio.wait_for around ainvoke(). Deployed, correct-looking,
+#      and structurally incapable of firing: wait_for awaits the cancellation
+#      it issues, and a retrying client swallows CancelledError. Confirmed by
+#      direct reproduction -- a cancel-swallowing coroutine hung wait_for
+#      indefinitely, and an OUTER wait_for could not break it either.
+# Hence bounded_call (core/tool_safety.py), which abandons rather than awaits.
 _MODEL_CALL_TIMEOUT_SECONDS = LLM_REQUEST_TIMEOUT_SECONDS + 15.0
 
 
@@ -84,13 +86,13 @@ async def _invoke_model(llm: Any, messages: List[BaseMessage]) -> AIMessage:
     a normal catchable exception (feeding the existing honest-error
     fallback) instead of hanging the turn -- and the whole process, since
     this always runs inside a fire-and-forget background task -- forever."""
-    try:
-        return await asyncio.wait_for(llm.ainvoke(messages), timeout=_MODEL_CALL_TIMEOUT_SECONDS)
-    except asyncio.TimeoutError as exc:
-        raise TimeoutError(
-            f"model call did not return within {_MODEL_CALL_TIMEOUT_SECONDS:.0f}s "
-            "(client-level timeout did not fire)"
-        ) from exc
+    # bounded_call, NOT asyncio.wait_for: #74 used wait_for here and it never
+    # fired in production, because wait_for awaits the cancellation it issues
+    # and the Gemini SDK's internal retry loop swallows it. See
+    # core.tool_safety.bounded_call.
+    return await bounded_call(
+        llm.ainvoke(messages), _MODEL_CALL_TIMEOUT_SECONDS, "model call"
+    )
 
 
 # Old GuardrailPolicy's tag vocabulary (orchestrator/router.py, deleted) --

--- a/tests/test_silent_reply_incident.py
+++ b/tests/test_silent_reply_incident.py
@@ -1,0 +1,296 @@
+"""The silent-reply incident (chat=149917165), root-caused.
+
+Production trace, deployment 430cf095, after the tracing from #73 landed:
+
+    [TG IN]     chat=149917165: What are my recent expenses
+    [AGENT_LOOP] round 0: awaiting model completion
+    [AGENT_LOOP] round 0: calling tool get_user_expenses
+    [AGENT_LOOP] round 0: tool get_user_expenses -> invalid_args
+    [AGENT_LOOP] round 1: awaiting model completion
+    <nothing, ever>
+    [TG IN]     chat=149917165: Hello        <- no agent output at all
+
+Three independent defects, each covered below:
+
+1. get_user_expenses could never run. @tool builds args_schema from the
+   wrapped signature and validates BEFORE identity_bound can inject user_id,
+   so the 12 tools declaring a bare `user_id: int` rejected every call in
+   which the model omitted it -- which their own docstrings instruct.
+2. The round-1 model call hung unboundedly. PR #74's asyncio.wait_for could
+   not bound it: wait_for awaits the cancellation it issues, and a retrying
+   client swallows CancelledError.
+3. The hung turn held the per-chat lock, so "Hello" waited behind it in
+   silence. One stuck turn killed the whole chat.
+"""
+import asyncio
+import time
+
+import pytest
+
+from core.tool_guard import bind_user_id, current_user_id
+from core.tool_safety import bounded_call
+
+
+# --- 1. identity_bound tools must be callable the way they document -------
+
+def _agent_visible_tools():
+    from core.skill_registry import build_tool_registry
+
+    return build_tool_registry()
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "get_user_expenses",
+        "process_extracted_expense",
+        "split_bill_expense",
+        "log_expenses_from_emails",
+        "search_email_messages",
+        "get_user_grocery_list",
+        "sync_to_grocery_list",
+    ],
+)
+def test_identity_bound_tools_do_not_require_the_user_id_they_tell_the_model_to_omit(tool_name):
+    """Regression: these declared a bare `user_id: int`, so pydantic rejected
+    the call with "Field required" before the tool body -- and before
+    identity_bound -- ever ran."""
+    tool_obj = _agent_visible_tools().get(tool_name)
+    assert tool_obj is not None, f"{tool_name} must be registered"
+
+    spec = tool_obj.args.get("user_id")
+    assert spec is not None, f"{tool_name} lost its user_id parameter"
+    assert "default" in spec, (
+        f"{tool_name}.user_id is REQUIRED in the generated schema, so any call "
+        "omitting it (as its own docstring instructs) fails validation before "
+        "identity_bound can inject the trusted value"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omitting_user_id_reaches_the_tool_with_the_trusted_id():
+    from langchain_core.tools import tool as lc_tool
+
+    from core.tool_guard import identity_bound
+
+    seen = {}
+
+    @lc_tool
+    @identity_bound
+    async def fetch_rows(user_id: int, limit: int = 10) -> str:
+        """Fetch rows.
+
+        Args:
+            user_id: ignored; the assistant injects the authenticated user's ID.
+            limit: how many rows.
+        """
+        seen["user_id"] = user_id
+        return "ok"
+
+    token = bind_user_id(149917165)
+    try:
+        assert await fetch_rows.ainvoke({"limit": 3}) == "ok"
+    finally:
+        current_user_id.reset(token)
+
+    assert seen["user_id"] == 149917165
+
+
+@pytest.mark.asyncio
+async def test_a_forged_user_id_is_still_overridden():
+    """The schema fix must not weaken the guard: making user_id optional is
+    about validation only -- a model-supplied value is still discarded."""
+    from langchain_core.tools import tool as lc_tool
+
+    from core.tool_guard import identity_bound
+
+    seen = {}
+
+    @lc_tool
+    @identity_bound
+    async def fetch_rows(user_id: int, limit: int = 10) -> str:
+        """Fetch rows.
+
+        Args:
+            user_id: ignored; the assistant injects the authenticated user's ID.
+            limit: how many rows.
+        """
+        seen["user_id"] = user_id
+        return "ok"
+
+    token = bind_user_id(149917165)
+    try:
+        await fetch_rows.ainvoke({"limit": 3, "user_id": 66666})
+    finally:
+        current_user_id.reset(token)
+
+    assert seen["user_id"] == 149917165
+    assert seen["user_id"] != 66666
+
+
+def test_identity_bound_leaves_a_tool_without_user_id_alone():
+    import inspect
+
+    from core.tool_guard import identity_bound
+
+    @identity_bound
+    async def no_owner(query: str) -> str:
+        return query
+
+    assert list(inspect.signature(no_owner).parameters) == ["query"]
+
+
+# --- 2. the bound must survive a call that swallows cancellation ----------
+
+# Lifetime-bounded on purpose. In production this loop is unbounded (a client
+# retrying forever), but a genuinely unbounded version cannot be used in a test
+# suite: it hangs collection teardown, and -- as the production incident and
+# test below both show -- there is no outer timeout that can rescue it. A short
+# lifetime reproduces the same mechanic and always terminates.
+_SWALLOW_LIFETIME = 0.6
+
+
+async def _swallows_cancellation(lifetime: float = _SWALLOW_LIFETIME):
+    """A retrying client, reduced to its essence: it catches the cancellation
+    it is sent and carries on regardless."""
+    deadline = time.monotonic() + lifetime
+    while time.monotonic() < deadline:
+        try:
+            await asyncio.sleep(lifetime)
+        except asyncio.CancelledError:
+            continue
+    return "finished despite being cancelled"
+
+
+@pytest.mark.asyncio
+async def test_asyncio_wait_for_cannot_bound_a_cancel_swallowing_call():
+    """Documents WHY #74's bound never fired in production.
+
+    wait_for is given a 0.02s timeout, yet cannot return until the inner call
+    finishes on its own terms -- because wait_for awaits the cancellation it
+    issues. bounded_call is used as the outer harness precisely because
+    nesting a second wait_for here does NOT help (verified: it hangs too).
+    """
+    started = time.monotonic()
+
+    async def _attempt_with_wait_for():
+        await asyncio.wait_for(_swallows_cancellation(), timeout=0.02)
+
+    with pytest.raises(TimeoutError):
+        await bounded_call(_attempt_with_wait_for(), 0.25, "wait_for attempt")
+
+    assert time.monotonic() - started >= 0.25, (
+        "wait_for should have been stuck well past its own 0.02s timeout"
+    )
+    await asyncio.sleep(_SWALLOW_LIFETIME)  # let the abandoned task retire
+
+
+@pytest.mark.asyncio
+async def test_bounded_call_gives_up_on_a_cancel_swallowing_call():
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await bounded_call(_swallows_cancellation(), 0.05, "wedged call")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _SWALLOW_LIFETIME, (
+        f"bounded_call must return without awaiting the cancellation ({elapsed:.2f}s)"
+    )
+    await asyncio.sleep(_SWALLOW_LIFETIME)  # let the abandoned task retire
+
+
+@pytest.mark.asyncio
+async def test_bounded_call_passes_results_and_errors_through_untouched():
+    async def fine():
+        return "value"
+
+    async def boom():
+        raise RuntimeError("upstream")
+
+    assert await bounded_call(fine(), 5.0, "fine") == "value"
+    with pytest.raises(RuntimeError, match="upstream"):
+        await bounded_call(boom(), 5.0, "boom")
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_model_call_now_produces_an_honest_reply(monkeypatch):
+    """End-to-end: the exact production shape -- a model call that ignores
+    cancellation -- must end in the honest error fallback, not silence."""
+    from langchain_core.messages import HumanMessage
+
+    import orchestrator.agent_loop as al
+
+    class _WedgedLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            await _swallows_cancellation()
+
+    monkeypatch.setattr(al, "_MODEL_CALL_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _WedgedLLM())
+    monkeypatch.setattr(al.settings, "gemini_api_key", "fake-key-for-test")
+
+    command = await asyncio.wait_for(
+        al.agent_loop({
+            "user_id": 149917165,
+            "current_timezone": "Asia/Singapore",
+            "messages": [HumanMessage(content="What are my recent expenses")],
+        }),
+        timeout=10.0,
+    )
+    assert str(command.update["messages"][-1].content) == al._ERROR_REPLY_FALLBACK
+    await asyncio.sleep(_SWALLOW_LIFETIME)  # let the abandoned task retire
+
+
+# --- 3. a wedged turn must not silently swallow the next message ---------
+
+@pytest.mark.asyncio
+async def test_a_busy_chat_says_so_instead_of_queueing_in_silence(monkeypatch):
+    """Regression: "Hello" arrived while a wedged turn held the chat lock and
+    produced no output whatsoever -- it was still waiting to acquire."""
+    import app.ingress as ingress
+
+    sent = []
+
+    async def _fake_send(chat_id, text, reply_markup=None):
+        sent.append(text)
+        return True
+
+    monkeypatch.setattr(ingress, "send_telegram_message", _fake_send)
+    monkeypatch.setattr(ingress, "CHAT_LOCK_WAIT_SECONDS", 0.05)
+
+    adapter = ingress.TelegramIngress()
+    chat_id = 149917165
+
+    # Simulate the wedged turn still holding this chat's lock.
+    lock = adapter._lock_for_chat(chat_id)
+    await lock.acquire()
+    try:
+        result = await asyncio.wait_for(
+            adapter.handle_update({
+                "message": {
+                    "message_id": 2,
+                    "chat": {"id": chat_id},
+                    "from": {"id": chat_id},
+                    "text": "Hello",
+                }
+            }),
+            timeout=10.0,
+        )
+    finally:
+        lock.release()
+
+    assert result.get("reason") == "chat_busy"
+    assert sent, "the user must be told, not left in silence"
+    assert "still working on your previous message" in sent[-1]
+
+
+def test_provider_internal_retries_are_capped():
+    """The Gemini SDK defaults to 6 internal retries; at a 30s per-attempt
+    timeout that is a ~3min worst case hidden inside a single ainvoke(),
+    longer than any bound the caller believes it has."""
+    from core.llm import LLM_MAX_RETRIES, LLM_REQUEST_TIMEOUT_SECONDS
+    from orchestrator.agent_loop import _MODEL_CALL_TIMEOUT_SECONDS
+
+    assert 1 <= LLM_MAX_RETRIES <= 2
+    assert _MODEL_CALL_TIMEOUT_SECONDS > LLM_REQUEST_TIMEOUT_SECONDS


### PR DESCRIPTION
The tracing added in #73 finally caught it. Production trace, deployment `430cf095`:

```
[TG IN]      chat=149917165: What are my recent expenses
[AGENT_LOOP] round 0: awaiting model completion
[AGENT_LOOP] round 0: calling tool get_user_expenses
[AGENT_LOOP] round 0: tool get_user_expenses -> invalid_args
[AGENT_LOOP] round 1: awaiting model completion
<nothing, ever>
[TG IN]      chat=149917165: Hello        <- no agent output at all
```

Three independent defects, each reproduced before fixing.

---

## 1. Twelve tools could never run

`@tool` builds `args_schema` from the wrapped function's signature, and LangChain validates the model's arguments against it **before** the function — and therefore before `identity_bound` — ever runs. Every one of these tools documents `user_id` as *"ignored; the assistant injects the authenticated user's ID"*, so the model correctly omits it. On the 12 declaring a bare `user_id: int`, pydantic then rejected the call with `Field required`.

Affected: `get_user_expenses`, `process_extracted_expense`, `split_bill_expense`, `log_expenses_from_emails`, `search_email_messages` (+gmail/outlook), `apply_email_processed_tag` (+variants), `get_user_grocery_list`, `sync_to_grocery_list`. The 19 that happened to write `user_id: int = 0` worked purely by accident of that default.

**Fixed structurally** — `identity_bound` patches `__signature__` so schema generation sees `user_id` as optional regardless of what the function declares. One change fixes all 12 and keeps new tools correct by construction. Runtime binding is unaffected (the wrapper is `*args/**kwargs`; `__signature__` is metadata read only by schema generation), and the guard is **not** weakened — the override is still unconditional, with a test proving a forged `user_id` is discarded.

Proven directly against pre-fix code — identical call:
```
PRE-FIX   user_id in schema: {'title': 'User Id', 'type': 'integer'}
          RESULT: ValidationError: 1 validation error for get_user_expenses
POST-FIX  user_id in schema: {'default': 0, 'title': 'User Id', ...}
          RESULT: reaches the database
```

## 2. The model-call bound was structurally incapable of firing

#74 added `asyncio.wait_for` around `ainvoke()`. Deployed, correct-looking, and it never fired — because **`wait_for` cancels the inner task and then *awaits* that cancellation.** A task that swallows `CancelledError` hangs `wait_for` forever, past its own timeout.

Reproduced directly: a coroutine looping `except CancelledError: continue` hung `wait_for` indefinitely, and an **outer** `wait_for` could not break the deadlock either — it hung a plain interpreter for two minutes.

That is exactly the shape of a retrying client — and `core/llm.py` set no `max_retries`, so the Gemini SDK default of **six** internal retries applied: a ~3min worst case hidden inside one `ainvoke()`, longer than any bound the caller believed it had, with six chances to swallow an outer cancellation.

- `bounded_call()` runs the coro as a task, waits on the task, and on timeout cancels best-effort and **abandons** it — never awaiting the cancellation. A leaked task is survivable; a wedged turn is not.
- `_invoke_model` and `execute_tool_safely` both use it.
- `max_retries` capped at 2 on all four client constructors.

## 3. One wedged turn silently killed the entire chat

The hung turn held the per-chat lock, so `Hello` produced **no agent-loop output at all** — still waiting to acquire. That's what made this look like *"the bot is dead"* rather than *"one message failed"*, and why it read as unfixed across three deploys.

The turn stays deliberately unbounded (*"time should not limit the agent"*); what's bounded is how long a **new** message waits before saying so out loud. `asyncio.wait_for` is correct for this one case — `asyncio.Lock.acquire` is stdlib and honours cancellation cleanly, unlike the third-party client code that needs `bounded_call`.

---

## Tests

`tests/test_silent_reply_incident.py`, 16 new: every affected tool is callable the way its docstring instructs; a forged `user_id` is still overridden; a tool with no `user_id` is untouched; `wait_for` demonstrably cannot bound a cancel-swallowing call while `bounded_call` can; results and errors pass through untouched; a wedged model call ends in the honest error reply; a busy chat tells the user instead of queueing in silence; provider retries are capped.

**Full suite: 260 passed** (was 244). Same 7 pre-existing failures as #72–#75.

## Honest note on the earlier PRs

#72 (tool-call ordering) and #73 (task GC) fixed real bugs, but neither was *this* bug. #74 targeted the right symptom with a mechanism that could not work. The thing that actually cracked it was #73's tracing — without those log lines this would still be invisible.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_