### PR TITLE
feat(llm): switch the agent to gemini-3.7-flash, steered by thinking_level

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     # AI & Multimodal Models
     google_api_key: Optional[str] = None
     gemini_api_key: Optional[str] = None
-    gemini_model: str = "gemini-2.5-flash"
+    gemini_model: str = "gemini-3.7-flash"
     gemini_judge_model: str = "gemini-3.1-pro-preview"
     deepseek_api_key: Optional[str] = None
     deepseek_base_url: str = "https://api.deepseek.com/v1"

--- a/core/llm.py
+++ b/core/llm.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from enum import Enum
 from typing import Any, Dict, Union
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -49,6 +50,54 @@ THINKING_CONFIGS: Dict[str, Dict[str, Any]] = {
     },
 }
 
+# Gemini 3.x Flash models dropped the sampling parameters entirely: passing
+# temperature/top_p/top_k to them is a 400, not a silently-ignored field.
+# Google's own migration guidance for 3.7 Flash is explicit -- "remove
+# deprecated sampling parameters (temperature, top_p, top_k)" -- and directs
+# callers to thinking_level instead.
+#
+# langchain-google-genai carries its own copy of this list
+# (_FIXED_SAMPLING_AND_NO_PREFILL_MODELS) and would strip the parameters for
+# us, but 4.3.2 predates gemini-3.7-flash's 2026-08-13 GA and so knows only
+# 3.5-flash-lite and 3.6-flash. Ours is the superset. When the library
+# catches up this can defer to it instead.
+_NO_SAMPLING_PARAM_MODELS = frozenset(
+    {"gemini-3.5-flash-lite", "gemini-3.6-flash", "gemini-3.7-flash"}
+)
+
+
+def _rejects_sampling_params(model_name: str) -> bool:
+    """Whether `model_name` 400s on temperature/top_p/top_k."""
+    normalized = (model_name or "").lower().rsplit("/", 1)[-1]
+    normalized = re.sub(r"-\d{3}$", "", normalized)  # strip a -001 style suffix
+    return normalized in _NO_SAMPLING_PARAM_MODELS
+
+
+def _normalize_thinking_level(complexity: Union[ThinkingLevel, str]) -> str:
+    level = complexity.value if isinstance(complexity, ThinkingLevel) else str(complexity).lower()
+    if level not in THINKING_CONFIGS:
+        logger.warning(f"Unknown thinking complexity '{complexity}', falling back to 'medium'.")
+        level = ThinkingLevel.MEDIUM.value
+    return level
+
+
+def _gemini_reasoning_kwargs(
+    model_name: str, temperature: float, complexity: Union[ThinkingLevel, str]
+) -> Dict[str, Any]:
+    """Sampling/reasoning kwargs appropriate to `model_name`.
+
+    For a model that still takes sampling parameters, that is just the
+    temperature it was called with. For a Gemini 3.x Flash that rejects them,
+    reasoning depth is steered by thinking_level instead -- which this repo
+    already has a vocabulary for: ThinkingLevel's low/medium/high are exactly
+    the values 3.7 Flash accepts (it dropped "minimal"). Previously that enum
+    only ever reached DeepSeek; on Gemini it was computed and discarded.
+    """
+    if _rejects_sampling_params(model_name):
+        return {"thinking_level": _normalize_thinking_level(complexity)}
+    return {"temperature": temperature}
+
+
 def get_llm(
     role: str = "agent_core",
     complexity: Union[ThinkingLevel, str] = ThinkingLevel.MEDIUM,
@@ -71,9 +120,9 @@ def get_llm(
         return ChatGoogleGenerativeAI(
             model=settings.gemini_model,
             google_api_key=api_key,
-            temperature=temperature,
             timeout=LLM_REQUEST_TIMEOUT_SECONDS,
             max_retries=LLM_MAX_RETRIES,
+            **_gemini_reasoning_kwargs(settings.gemini_model, temperature, complexity),
         )
 
     elif role == "agent_core":
@@ -83,9 +132,9 @@ def get_llm(
             return ChatGoogleGenerativeAI(
                 model=settings.gemini_model,
                 google_api_key=api_key,
-                temperature=temperature,
                 timeout=LLM_REQUEST_TIMEOUT_SECONDS,
-            max_retries=LLM_MAX_RETRIES,
+                max_retries=LLM_MAX_RETRIES,
+                **_gemini_reasoning_kwargs(settings.gemini_model, temperature, complexity),
             )
 
         api_key = settings.deepseek_api_key or "test_deepseek_key"

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -13,10 +13,21 @@ from core.llm import (
 def test_multimodal_io_llm_initialization():
     """Verify that role='multimodal_io' returns a ChatGoogleGenerativeAI instance for Gemini Flash."""
     from core.config import settings
+    from core.llm import _rejects_sampling_params
+
     llm = get_llm(role="multimodal_io", temperature=0.2)
     assert isinstance(llm, ChatGoogleGenerativeAI)
     assert llm.model == settings.gemini_model
-    assert llm.temperature == 0.2
+    # Whether temperature is forwarded depends on the configured model:
+    # Gemini 3.x Flash 400s on sampling parameters and takes thinking_level
+    # instead (see core.llm._gemini_reasoning_kwargs). Asserted per-model so
+    # this stays a real check whichever model is configured, rather than
+    # hardcoding one era's behaviour.
+    if _rejects_sampling_params(settings.gemini_model):
+        assert llm.temperature is None
+        assert llm.thinking_level is not None
+    else:
+        assert llm.temperature == 0.2
 
     # Verify convenience helper
     helper_llm = get_multimodal_llm()

--- a/tests/test_llm_model_config.py
+++ b/tests/test_llm_model_config.py
@@ -1,0 +1,120 @@
+"""Model selection and per-model reasoning parameters.
+
+Gemini 3.x Flash dropped the sampling parameters: temperature/top_p/top_k are
+a 400 on those models, not a silently-ignored field. Google's migration
+guidance for 3.7 Flash is to remove them and steer with thinking_level.
+
+langchain-google-genai keeps its own list of such models and would strip the
+parameters for us, but the pinned 4.3.2 predates gemini-3.7-flash's
+2026-08-13 GA -- it knows only 3.5-flash-lite and 3.6-flash. So switching the
+model without this handling would have sent temperature=0.7 straight through
+and 400'd every single agent call.
+"""
+import pytest
+
+from core.config import settings
+from core.llm import (
+    ThinkingLevel,
+    _rejects_sampling_params,
+    get_agent_llm,
+    get_judge_llm,
+    get_multimodal_llm,
+)
+
+
+@pytest.fixture(autouse=True)
+def _gemini_provider(monkeypatch):
+    monkeypatch.setattr(settings, "llm_provider", "gemini")
+    monkeypatch.setattr(settings, "gemini_api_key", "fake-key-for-construction-test")
+
+
+@pytest.mark.parametrize(
+    "model_name,rejects",
+    [
+        ("gemini-3.7-flash", True),
+        ("gemini-3.6-flash", True),
+        ("gemini-3.5-flash-lite", True),
+        ("gemini-3.7-flash-001", True),      # pinned point release
+        ("models/gemini-3.7-flash", True),   # fully-qualified form
+        ("gemini-2.5-flash", False),         # the model we came from
+        ("gemini-3.1-pro-preview", False),   # the judge
+    ],
+)
+def test_sampling_parameter_support_is_detected_per_model(model_name, rejects):
+    assert _rejects_sampling_params(model_name) is rejects
+
+
+def test_the_agent_model_sends_thinking_level_and_no_temperature(monkeypatch):
+    monkeypatch.setattr(settings, "gemini_model", "gemini-3.7-flash")
+
+    llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7)
+
+    assert llm.model == "gemini-3.7-flash"
+    assert llm.thinking_level == "medium"
+    assert llm.temperature is None, (
+        "gemini-3.7-flash 400s on temperature -- it must never be sent"
+    )
+
+
+@pytest.mark.parametrize(
+    "complexity,expected",
+    [(ThinkingLevel.LOW, "low"), (ThinkingLevel.MEDIUM, "medium"), (ThinkingLevel.HIGH, "high")],
+)
+def test_thinking_level_follows_the_requested_complexity(monkeypatch, complexity, expected):
+    """ThinkingLevel used to be computed and then discarded on the Gemini
+    path -- it only ever reached DeepSeek. Now it actually steers Gemini."""
+    monkeypatch.setattr(settings, "gemini_model", "gemini-3.7-flash")
+    assert get_agent_llm(complexity=complexity).thinking_level == expected
+
+
+def test_an_unknown_complexity_falls_back_to_medium(monkeypatch):
+    monkeypatch.setattr(settings, "gemini_model", "gemini-3.7-flash")
+    assert get_agent_llm(complexity="nonsense").thinking_level == "medium"
+
+
+def test_the_vision_model_gets_the_same_treatment(monkeypatch):
+    """get_multimodal_llm shares settings.gemini_model, so the switch hits the
+    receipt-photo path too."""
+    monkeypatch.setattr(settings, "gemini_model", "gemini-3.7-flash")
+
+    mm = get_multimodal_llm(temperature=0.2)
+
+    assert mm.temperature is None
+    assert mm.thinking_level == "medium"
+
+
+def test_a_model_that_still_takes_temperature_keeps_it(monkeypatch):
+    """The guard must be per-model, not a blanket removal -- older models and
+    the judge still accept sampling parameters."""
+    monkeypatch.setattr(settings, "gemini_model", "gemini-2.5-flash")
+
+    llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7)
+
+    assert llm.temperature == 0.7
+    assert llm.thinking_level is None
+
+
+def test_the_judge_model_is_unaffected_by_the_agent_switch():
+    judge = get_judge_llm(temperature=0.0)
+
+    assert judge.model == settings.gemini_judge_model
+    assert judge.temperature == 0.0
+
+
+def test_the_configured_default_is_the_intended_model():
+    """Guards against the code default drifting away from what production
+    runs. NOTE: Railway sets GEMINI_MODEL explicitly, and that env var
+    overrides this default -- both must be changed together."""
+    from core.config import Settings
+
+    assert Settings().gemini_model == "gemini-3.7-flash"
+
+
+def test_the_deepseek_path_is_untouched(monkeypatch):
+    monkeypatch.setattr(settings, "llm_provider", "deepseek")
+    monkeypatch.setattr(settings, "deepseek_api_key", "fake-deepseek-key")
+
+    llm = get_agent_llm(complexity=ThinkingLevel.HIGH, temperature=0.7)
+
+    assert llm.temperature == 0.7
+    assert llm.reasoning_effort == "high"


### PR DESCRIPTION
Switches the agent from `gemini-2.5-flash` to `gemini-3.7-flash` (GA 2026-08-13), chasing better tool-calling and agentic behaviour.

## This is not just a model-string change

**Gemini 3.x Flash dropped the sampling parameters.** Passing `temperature`/`top_p`/`top_k` to `gemini-3.7-flash` is a **400**, not a silently-ignored field — Google's migration guidance says to remove them and use `thinking_level` instead.

`langchain-google-genai` keeps its own list of such models (`_FIXED_SAMPLING_AND_NO_PREFILL_MODELS`) and would strip them for us — but the pinned **4.3.2 predates 3.7 Flash's release** and knows only `gemini-3.5-flash-lite` and `gemini-3.6-flash`:

```python
_FIXED_SAMPLING_AND_NO_PREFILL_MODELS = frozenset(
    {"gemini-3.5-flash-lite", "gemini-3.6-flash"}    # no 3.7
)
```

So flipping `GEMINI_MODEL` alone would have sent `temperature=0.7` straight through and 400'd **every agent call, every vision call, every turn** — a total outage. `core/llm.py` now decides per-model:

- `_rejects_sampling_params()` — our superset of the library's list; handles pinned point releases (`gemini-3.7-flash-001`) and the `models/`-qualified form. Defers to the library once it catches up.
- `_gemini_reasoning_kwargs()` — `temperature` for models that still take it, `thinking_level` for those that don't.

## ThinkingLevel finally reaches Gemini

The repo's `ThinkingLevel` enum (`low`/`medium`/`high`) is exactly the vocabulary 3.7 Flash accepts — it dropped `minimal`. Until now that enum was **computed on the Gemini path and then discarded**; only DeepSeek ever saw it, as `reasoning_effort`. Reasoning depth is now genuinely steerable on Gemini, which is the actual lever for the agentic quality this switch is after. Callers keep their existing `MEDIUM` default, so nothing changes implicitly — bumping the agent loop to `HIGH` is now a one-line knob if you want more deliberation per turn.

Verified construction:
```
agent  -> gemini-3.7-flash        | thinking_level: medium | temperature: None
vision -> gemini-3.7-flash        | thinking_level: medium | temperature: None
judge  -> gemini-3.1-pro-preview  | thinking_level: None   | temperature: 0.0
```

Deliberately scoped: the judge (`gemini-3.1-pro-preview`) still takes sampling parameters and is untouched; the DeepSeek path is untouched. Both asserted by test.

## Tests

`tests/test_llm_model_config.py`, 17 new: per-model detection across seven name forms; the agent sends `thinking_level` and never `temperature`; `thinking_level` tracks requested complexity; unknown complexity falls back to medium; the vision model (which shares `gemini_model`) gets the same treatment; a model that still takes temperature keeps it; judge unaffected; DeepSeek unchanged.

`test_llm_factory.py::test_multimodal_io_llm_initialization` hardcoded `temperature == 0.2`. That assertion's premise is now false for the configured model — sending temperature *is* the bug — so it's rewritten to assert **per-model** rather than flipped or deleted, staying a real check either way.

**Full suite: 277 passed** (was 260). Same 7 pre-existing failures as #72–#76.

## Deploying

⚠️ `GEMINI_MODEL` is set as a Railway variable and **overrides this code default**, so merging alone does not switch production — it only makes *both* models safe. The variable gets flipped separately, after this deploy lands, so the handling is in place before the model changes.

Sources: [Gemini 3.7 Flash model docs](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash) · [migration notes](``https://medium.com/google-cloud/migrating-to-gemini-3-7-flash-what-breaks-what-changed-and-how-to-fix-your-code-8f18385f0833``)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_