### PR TITLE
fix(observability): make the ops sweep and incident reporting detect real failures

### DIFF
--- a/app/ingress.py
+++ b/app/ingress.py
@@ -4,6 +4,7 @@ import html
 import json
 import os
 import re
+import time
 from typing import Dict, Any, List, Optional
 import httpx
 from langchain_core.messages import AIMessage
@@ -250,6 +251,13 @@ class TelegramIngress:
     # scaling here); a multi-instance deployment would need a distributed
     # lock (e.g. a Postgres advisory lock keyed by chat_id) instead.
     _chat_locks: Dict[int, asyncio.Lock] = {}
+    # When each currently-held chat lock was acquired (monotonic seconds).
+    # A turn is deliberately unbounded, so "holding the lock" is normal --
+    # holding it for many minutes is not, and that is precisely the shape of
+    # the silent-reply outage: one wedged turn, every later message for that
+    # chat queued invisibly behind it. Nothing could see that state, which is
+    # why the 15-minute operations sweep reported "0 issues" throughout.
+    _chat_lock_held_since: Dict[int, float] = {}
 
     @classmethod
     def _lock_for_chat(cls, chat_id: int) -> asyncio.Lock:
@@ -258,6 +266,20 @@ class TelegramIngress:
             lock = asyncio.Lock()
             cls._chat_locks[chat_id] = lock
         return lock
+
+    @classmethod
+    def wedged_chats(cls, threshold_seconds: float) -> List[Dict[str, Any]]:
+        """Chats whose turn has held the lock longer than `threshold_seconds`.
+
+        Read by core.scheduler's operations sweep. Returns plain data (no
+        locks) so the caller cannot accidentally mutate scheduling state.
+        """
+        now = time.monotonic()
+        return [
+            {"chat_id": chat_id, "held_seconds": now - since}
+            for chat_id, since in sorted(cls._chat_lock_held_since.items())
+            if now - since > threshold_seconds
+        ]
 
     @staticmethod
     async def _typing_loop(chat_id: int, stop_event: asyncio.Event) -> None:
@@ -1304,9 +1326,11 @@ class TelegramIngress:
                     "and send that again.",
                 )
                 return {"status": "ok", "processed": False, "reason": "chat_busy"}
+            self._chat_lock_held_since[chat_id] = time.monotonic()
             try:
                 result = await get_assistant_graph().ainvoke(initial_state, config=config)
             finally:
+                self._chat_lock_held_since.pop(chat_id, None)
                 lock.release()
             interrupts = result.get("__interrupt__")
             if interrupts:

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -569,6 +569,13 @@ async def _scheduled_email_expense_sweep():
             print(f"[SWEEP] error for user {user_id}: {exc}")
 
 
+# A turn is deliberately unbounded (see agent_loop.MAX_TOOL_ROUNDS), so this
+# is not a limit -- nothing is cancelled. It is the point past which a still-
+# running turn is better explained by a wedge than by real work, and is worth
+# raising as an incident.
+WEDGED_CHAT_SECONDS = 300.0
+
+
 async def _run_operations_health_sweep():
     """Every 15 minutes, probe service health and record failures as GitHub issues.
 
@@ -621,7 +628,31 @@ async def _run_operations_health_sweep():
             "fingerprint": "scheduler_not_running",
         })
 
-    # 4. Telegram bot token presence (the ingress can't start at all without it)
+    # 4. Wedged chats -- a turn holding its per-chat lock far longer than any
+    #    real turn should. This is the probe that would have caught the
+    #    silent-reply outage: every config check below stayed green while the
+    #    bot answered nobody, because they check whether the service is
+    #    CONFIGURED, never whether it is WORKING.
+    #    Imported lazily: app.ingress imports from this module.
+    try:
+        from app.ingress import TelegramIngress
+
+        for wedged in TelegramIngress.wedged_chats(WEDGED_CHAT_SECONDS):
+            probes.append({
+                "subsystem": "agent_loop",
+                "severity": "P1",
+                "error_context": (
+                    f"Chat {wedged['chat_id']} has held its turn lock for "
+                    f"{wedged['held_seconds']:.0f}s. Its turn is wedged and every "
+                    "subsequent message from that chat is queued behind it."
+                ),
+                "detection_source": "operations_health",
+                "fingerprint": f"wedged_chat_{wedged['chat_id']}",
+            })
+    except Exception as exc:  # noqa: BLE001 - a probe must never kill the sweep
+        print(f"[OPS SWEEP] wedged-chat probe failed: {exc}")
+
+    # 5. Telegram bot token presence (the ingress can't start at all without it)
     if not settings.telegram_bot_token or settings.telegram_bot_token == "test_bot_token":
         probes.append({
             "subsystem": "telegram",

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -42,7 +42,12 @@ from langgraph.errors import GraphBubbleUp
 from langgraph.graph import END
 from langgraph.types import Command
 
-from core.audit import log_capability_request, perform_conversation_audit, should_audit_conversation
+from core.audit import (
+    log_capability_request,
+    perform_conversation_audit,
+    record_operation_event,
+    should_audit_conversation,
+)
 from core.background import fire_and_forget
 from core.config import settings
 from core.llm import LLM_REQUEST_TIMEOUT_SECONDS, ThinkingLevel, extract_llm_text, get_agent_llm, get_multimodal_llm
@@ -62,6 +67,19 @@ URL_PATTERN = re.compile(r"https?://\S+")
 # truly broken loop (a tool whose result always makes the model want to call
 # it again); a real multi-step request should never come remotely close.
 MAX_TOOL_ROUNDS = 40
+
+# Tool outcomes worth filing an incident for, and at what severity. A tool the
+# model cannot successfully call is a defect in that tool -- a wrong schema, a
+# misleading description, a broken dependency -- not normal operation.
+# "success" and "unknown_tool" are excluded: the former is fine, the latter is
+# the model inventing a name, which is a prompt issue rather than a service
+# fault.
+_REPORTABLE_TOOL_FAILURES = {
+    "invalid_args": "P2",
+    "timeout": "P2",
+    "error": "P2",
+    "gave_up": "P1",
+}
 
 # Backstop for a single model call -- NOT another disguised wall-clock
 # ceiling on the turn (that stays MAX_TOOL_ROUNDS' job, unbounded per the
@@ -542,11 +560,68 @@ async def _execute_tool_calls(
         outcome = outcomes[i]
         status = "returned" if outcome.ok else f"-> {outcome.status}"
         print(f"[AGENT_LOOP] {round_label}: tool {name} {status}")
+        if outcome.status in _REPORTABLE_TOOL_FAILURES:
+            # A tool the model could not successfully call is a defect in that
+            # tool's schema, description or implementation -- never routine.
+            # The 12 identity_bound tools fixed in #76 returned invalid_args on
+            # every single call for as long as they existed, and nothing
+            # anywhere noticed. Deduped per (tool, failure kind), so this is
+            # one issue per broken tool carrying an occurrence count.
+            _report_agent_failure(
+                subsystem=f"tool:{name}",
+                error_context=f"Tool {name} returned {outcome.status}: {outcome.observation[:800]}",
+                severity=_REPORTABLE_TOOL_FAILURES[outcome.status],
+                fingerprint=f"agent_tool_{name}_{outcome.status}",
+                user_id=int(current_user_id.get() or 0),
+            )
         hist.append(
             ToolMessage(content=outcome.observation, tool_call_id=str(call.get("id") or name))
         )
 
     return link_tool_used
+
+
+def _report_agent_failure(
+    subsystem: str,
+    error_context: str,
+    *,
+    severity: str = "P2",
+    fingerprint: str,
+    user_id: int,
+    error_traceback: str | None = None,
+) -> None:
+    """File an operational incident for a failure the agent recovered from.
+
+    The detection gap this closes: agent_loop catches every exception from the
+    tool loop and answers with _ERROR_REPLY_FALLBACK, so a model timeout, a
+    provider 400 or a crashed tool became a friendly "something glitched"
+    message and nothing else. app/ingress.py's report_production_bug sits
+    OUTSIDE that catch, so it never fired for anything the agent loop handled
+    -- which is nearly everything. Meanwhile the 15-minute operations sweep
+    probes only static config (credentials present, DB reachable, scheduler
+    object running), all of which stayed green throughout a total
+    silent-reply outage.
+
+    record_operation_event dedups on `fingerprint`, so a failure that repeats
+    keeps ONE open issue with a recurrence count rather than filing hundreds.
+    Reporting is fire-and-forget and defensive: telemetry must never be able
+    to break the turn it is describing.
+    """
+    try:
+        fire_and_forget(
+            record_operation_event(
+                subsystem=subsystem,
+                error_context=error_context,
+                detection_source="agent_loop",
+                user_id=user_id or None,
+                thread_id=str(user_id) if user_id else None,
+                error_traceback=error_traceback,
+                fingerprint=fingerprint,
+                severity=severity,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - telemetry must never break a turn
+        print(f"[AGENT_LOOP] failed to record incident {fingerprint}: {exc}")
 
 
 async def _run_tool_loop(
@@ -853,7 +928,21 @@ async def agent_loop(state: AssistantState) -> Command[str]:
                 except GraphBubbleUp:
                     raise
                 except Exception as exc:  # noqa: BLE001 - never let an LLM error kill the turn
+                    import traceback
+
                     print(f"[AGENT_LOOP] tool loop failed, using fallback: {exc}")
+                    # The user just got a non-answer. That is a P1 incident, and
+                    # until now it was only ever a print: this except swallows
+                    # the failure, so ingress's report_production_bug (which
+                    # sits outside it) never saw a single one of them.
+                    _report_agent_failure(
+                        subsystem="agent_loop",
+                        error_context=f"Agent turn failed and fell back to an error reply: {exc}",
+                        severity="P1",
+                        fingerprint=f"agent_loop_failure_{type(exc).__name__}",
+                        user_id=user_id,
+                        error_traceback=traceback.format_exc(),
+                    )
                     content = _ERROR_REPLY_FALLBACK
     finally:
         current_user_id.reset(token)

--- a/tests/test_detection_blindspots.py
+++ b/tests/test_detection_blindspots.py
@@ -1,0 +1,220 @@
+"""Why the judge and the operations sweep stayed silent through an outage.
+
+On 2026-08-28 the bot suffered a total silent-reply outage: turns wedged,
+twelve identity_bound tools rejected every call with invalid_args, and users
+got nothing back. Throughout, `[OPS SWEEP] completed with 0 issue(s)
+recorded.` printed every fifteen minutes and not one GitHub issue was filed.
+
+That was structural, not bad luck. Four blind spots:
+
+1. The operations sweep probed only static configuration -- credentials
+   present, DB reachable, scheduler object running, token set. All four stay
+   green while the service answers nobody. It asked "is this CONFIGURED?",
+   never "is this WORKING?".
+2. agent_loop catches every tool-loop exception and answers with
+   _ERROR_REPLY_FALLBACK. app/ingress.py's report_production_bug sits outside
+   that catch, so it never saw a failure the agent loop handled -- i.e. almost
+   none of them.
+3. A tool failing validation was pure log noise. Twelve tools returned
+   invalid_args on every call for as long as they existed and nothing
+   anywhere counted it.
+4. A wedged turn was unobservable: it holds its per-chat lock, silently
+   queueing every later message from that chat, and no probe could see it.
+
+The judge (perform_conversation_audit) is a fifth, partly by design: it runs
+at the END of a completed turn and only every 4th human message, so a turn
+that never completes is invisible to it and 3 in 4 that do are skipped. These
+tests cover the four fixed above; the judge's cadence is left alone.
+"""
+import asyncio
+import time
+
+import pytest
+
+
+# --- 1 & 2: agent_loop reports what it used to swallow --------------------
+
+@pytest.mark.asyncio
+async def test_a_failed_turn_files_an_incident_instead_of_only_printing(monkeypatch):
+    """The user got a non-answer -- that is a P1, and it used to be a print."""
+    from langchain_core.messages import HumanMessage
+
+    import orchestrator.agent_loop as al
+
+    recorded = []
+
+    async def _spy(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(al, "record_operation_event", _spy)
+    monkeypatch.setattr(al.settings, "gemini_api_key", "fake-key-for-test")
+
+    class _BrokenLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            raise RuntimeError("simulated provider failure")
+
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _BrokenLLM())
+
+    command = await al.agent_loop({
+        "user_id": 149917165,
+        "current_timezone": "Asia/Singapore",
+        "messages": [HumanMessage(content="what are my recent expenses")],
+    })
+
+    # The user still gets the honest fallback...
+    assert str(command.update["messages"][-1].content) == al._ERROR_REPLY_FALLBACK
+    # ...and now somebody is told about it.
+    await asyncio.sleep(0.05)
+    assert recorded, "a failed turn must file an incident"
+    incident = recorded[0]
+    assert incident["severity"] == "P1"
+    assert incident["fingerprint"] == "agent_loop_failure_RuntimeError"
+    assert "simulated provider failure" in incident["error_context"]
+    assert incident["error_traceback"]
+
+
+# --- 3: a tool the model cannot call is a defect, and gets reported -------
+
+@pytest.mark.asyncio
+async def test_a_tool_rejecting_its_arguments_files_an_incident(monkeypatch):
+    """Reproduces the #76 shape: get_user_expenses returned invalid_args on
+    every call and nothing noticed."""
+    import orchestrator.agent_loop as al
+    from core.tool_safety import FailureLedger
+
+    recorded = []
+
+    async def _spy(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(al, "record_operation_event", _spy)
+
+    class _RejectsArgs:
+        name = "get_user_expenses"
+
+        async def ainvoke(self, args):
+            raise ValueError("Field required: user_id")
+
+    hist = []
+    await al._execute_tool_calls(
+        [{"name": "get_user_expenses", "args": {}, "id": "c1"}],
+        [_RejectsArgs()], hist, [], FailureLedger(), set(), round_label="round 0",
+    )
+
+    await asyncio.sleep(0.05)
+    assert recorded, "a tool failure must file an incident"
+    assert recorded[0]["fingerprint"] == "agent_tool_get_user_expenses_error"
+    assert recorded[0]["subsystem"] == "tool:get_user_expenses"
+
+
+@pytest.mark.asyncio
+async def test_a_successful_tool_call_files_nothing(monkeypatch):
+    """Telemetry must be signal, not noise."""
+    import orchestrator.agent_loop as al
+    from core.tool_safety import FailureLedger
+
+    recorded = []
+
+    async def _spy(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(al, "record_operation_event", _spy)
+
+    class _Works:
+        name = "get_bus_timings"
+
+        async def ainvoke(self, args):
+            return "Bus 10: 3 min"
+
+    await al._execute_tool_calls(
+        [{"name": "get_bus_timings", "args": {}, "id": "c1"}],
+        [_Works()], [], [], FailureLedger(), {"get_bus_timings"}, round_label="round 0",
+    )
+
+    await asyncio.sleep(0.05)
+    assert recorded == []
+
+
+def test_reportable_failures_exclude_success_and_unknown_tool():
+    from orchestrator.agent_loop import _REPORTABLE_TOOL_FAILURES
+
+    assert "success" not in _REPORTABLE_TOOL_FAILURES
+    assert "unknown_tool" not in _REPORTABLE_TOOL_FAILURES
+    assert _REPORTABLE_TOOL_FAILURES["gave_up"] == "P1"
+
+
+# --- 4: a wedged chat is observable, and the sweep looks --------------------
+
+@pytest.mark.asyncio
+async def test_a_wedged_chat_is_visible_while_a_healthy_turn_is_not():
+    from app.ingress import TelegramIngress
+
+    TelegramIngress._chat_lock_held_since.clear()
+    try:
+        now = time.monotonic()
+        TelegramIngress._chat_lock_held_since[111] = now - 600   # wedged 10 min
+        TelegramIngress._chat_lock_held_since[222] = now - 3     # normal turn
+
+        wedged = TelegramIngress.wedged_chats(threshold_seconds=300.0)
+
+        assert [w["chat_id"] for w in wedged] == [111]
+        assert wedged[0]["held_seconds"] > 300
+    finally:
+        TelegramIngress._chat_lock_held_since.clear()
+
+
+@pytest.mark.asyncio
+async def test_no_turn_in_flight_means_nothing_wedged():
+    from app.ingress import TelegramIngress
+
+    TelegramIngress._chat_lock_held_since.clear()
+    assert TelegramIngress.wedged_chats(threshold_seconds=300.0) == []
+
+
+@pytest.mark.asyncio
+async def test_the_operations_sweep_now_raises_a_wedged_chat(monkeypatch):
+    """The probe that would have caught the outage: every config check stayed
+    green while the bot answered nobody."""
+    import core.scheduler as sched
+    from app.ingress import TelegramIngress
+
+    recorded = []
+
+    async def _spy(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr("core.audit.record_operation_event", _spy)
+
+    TelegramIngress._chat_lock_held_since.clear()
+    TelegramIngress._chat_lock_held_since[149917165] = time.monotonic() - 900
+    try:
+        await sched._run_operations_health_sweep()
+    finally:
+        TelegramIngress._chat_lock_held_since.clear()
+
+    wedged = [r for r in recorded if r.get("fingerprint", "").startswith("wedged_chat_")]
+    assert wedged, "the sweep must report a wedged chat"
+    assert wedged[0]["severity"] == "P1"
+    assert wedged[0]["subsystem"] == "agent_loop"
+    assert "149917165" in wedged[0]["error_context"]
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_stays_quiet_when_the_service_is_actually_healthy(monkeypatch):
+    import core.scheduler as sched
+    from app.ingress import TelegramIngress
+
+    recorded = []
+
+    async def _spy(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr("core.audit.record_operation_event", _spy)
+    TelegramIngress._chat_lock_held_since.clear()
+
+    await sched._run_operations_health_sweep()
+
+    assert not [r for r in recorded if r.get("fingerprint", "").startswith("wedged_chat_")]


### PR DESCRIPTION
The judge and the operations sweep caught none of today's hiccups. That's structural, not bad luck.

Through a **total silent-reply outage** — twelve tools rejecting every call, turns wedging, users getting nothing — `[OPS SWEEP] completed with 0 issue(s) recorded.` printed every fifteen minutes and **not one issue was filed**.

Four blind spots. All four closed here.

---

## 1. The sweep asked "is this CONFIGURED?", never "is this WORKING?"

All four probes were static: OAuth credentials present, DB reachable, scheduler object running, Telegram token set. **Every one stayed green while the bot answered nobody** — none of them observes behaviour. A config linter wearing a health check's name.

Added the probe that would have caught it: a chat holding its per-chat lock beyond `WEDGED_CHAT_SECONDS` (300s) → **P1**. Nothing gets cancelled — turns stay deliberately unbounded per `MAX_TOOL_ROUNDS` — this only raises the alarm.

## 2. `agent_loop`'s catch-all hid every failure from the bug reporter

`agent_loop` catches every tool-loop exception and answers with `_ERROR_REPLY_FALLBACK`. `report_production_bug` sits **outside** that catch — so it never fired for anything the agent loop handled, which is nearly everything: the model-call timeout, the Gemini 400, the tool-loop crash. The user got "something glitched" and the incident died as a `print`.

A failed turn now files a P1 itself, fingerprinted by exception type, with traceback.

## 3. A tool the model couldn't call was pure log noise

The twelve `identity_bound` tools fixed in #76 returned `invalid_args` on **every call for as long as they existed**, and nothing counted it. A tool the model cannot successfully call is a defect in that tool — wrong schema, misleading description, broken dependency — never routine.

Non-success outcomes now file an incident, deduped per `(tool, failure kind)`: one issue with a recurrence count, not silence and not a flood. `success` and `unknown_tool` deliberately excluded.

## 4. A wedged turn was unobservable

It holds its chat lock and silently queues every later message from that chat — the mechanism that turned one stuck turn into *"the bot is dead"*. `TelegramIngress` now records lock acquisition time and exposes `wedged_chats()`, which probe 1 reads.

---

## Deliberately not changed: the judge's cadence

`perform_conversation_audit` runs at the **end of a completed turn**, and only every **4th** human message (`should_audit_conversation`, `every_n=4`). So a turn that never completes is invisible to it *by construction*, and 3 in 4 that do complete are skipped.

That's a real gap — but auditing every turn means a 3.1-pro call per message, which is a cost/design call that's yours, not mine. It's documented in the test module rather than changed unilaterally.

Worth noting the four fixes above **don't depend on it**: they report at the point of failure, which is strictly more reliable than sampling conversations after the fact. If you do want the judge more aggressive, the cheap version is auditing every turn that used a fallback regardless of cadence — say the word.

## Tests

`tests/test_detection_blindspots.py`, 8 new, **all confirmed failing pre-fix**: a failed turn files a P1 with traceback while still returning the honest fallback; a tool rejecting its arguments files an incident fingerprinted per tool; a successful call files nothing; the reportable table excludes success/unknown_tool; a wedged chat is visible while a healthy in-flight turn is not; nothing in flight means nothing wedged; the sweep raises a wedged chat as P1; the sweep stays quiet when healthy.

Reporting is fire-and-forget and defensive throughout — telemetry must never break the turn it describes.

**Full suite: 285 passed** (was 277). Same 7 pre-existing failures as #72–#77.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_