### PR TITLE
fix(llm): read Gemini 3.x list content via extract_llm_text, not str()

### DIFF
--- a/app/dashboard_api.py
+++ b/app/dashboard_api.py
@@ -45,6 +45,7 @@ from core.scheduler import (
     trigger_task_alert_now,
 )
 from capabilities.expenses.settlement import IouSettlementCommand, settle_iou
+from core.llm import extract_llm_text
 
 router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 
@@ -3018,7 +3019,7 @@ async def _llm_generate_block_json(prompt: str, board_context: Dict[str, Any]) -
         ai_message = await llm.ainvoke(
             [SystemMessage(content=system_prompt), HumanMessage(content=prompt[:1500])]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = _re.sub(r"^```(?:json)?|```$", "", raw, flags=_re.MULTILINE).strip()
         start, end = raw.find("{"), raw.rfind("}")
         if start == -1 or end <= start:

--- a/capabilities/expenses/tools.py
+++ b/capabilities/expenses/tools.py
@@ -657,7 +657,7 @@ async def extract_expense_from_text(user_text: str, recent_context: str = "") ->
             return _regex_extract_expense(user_text)
 
     try:
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
         parsed = json.loads(raw)
         if parsed.get("amount") is None:

--- a/capabilities/memory/tools.py
+++ b/capabilities/memory/tools.py
@@ -15,7 +15,7 @@ from sqlmodel import select
 
 from core.config import settings
 from core.db import async_session_factory
-from core.llm import ThinkingLevel, get_agent_llm
+from core.llm import ThinkingLevel, get_agent_llm, extract_llm_text
 from core.models import PointsBalance
 from core.tool_guard import identity_bound
 
@@ -95,7 +95,7 @@ async def extract_points_balance(user_text: str) -> Dict[str, Any]:
                 HumanMessage(content=(user_text or "")[:2000]),
             ]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
         import json
 

--- a/capabilities/recipes/tools.py
+++ b/capabilities/recipes/tools.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 
 from core.config import settings
 from core.db import async_session_factory
-from core.llm import ThinkingLevel, get_agent_llm
+from core.llm import ThinkingLevel, get_agent_llm, extract_llm_text
 from core.models import GroceryItem
 from core.tool_guard import identity_bound
 
@@ -62,7 +62,7 @@ async def parse_recipe_and_extract_ingredients(
                 ),
             ]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
     except Exception as exc:  # noqa: BLE001
         print(f"[RECIPES] LLM call failed: {exc}, using canned fallback")

--- a/capabilities/reminders/tools.py
+++ b/capabilities/reminders/tools.py
@@ -8,7 +8,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import tool
 
 from core.config import settings
-from core.llm import ThinkingLevel, get_agent_llm
+from core.llm import ThinkingLevel, get_agent_llm, extract_llm_text
 from core.tool_guard import identity_bound
 
 # A request must contain explicit repetition language before an eternal cron job may be created.
@@ -276,7 +276,7 @@ async def parse_reminder_request(user_text: str, recent_context: str = "") -> Di
                 ),
             ]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
     except Exception as exc:  # noqa: BLE001
         print(f"[REMINDERS] LLM call failed: {exc}")

--- a/capabilities/routes/tools.py
+++ b/capabilities/routes/tools.py
@@ -7,7 +7,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import tool
 
 from core.config import settings
-from core.llm import ThinkingLevel, get_agent_llm
+from core.llm import ThinkingLevel, get_agent_llm, extract_llm_text
 from capabilities.routes import lta
 
 
@@ -145,7 +145,7 @@ async def extract_route_request(user_text: str, recent_context: str = "") -> Dic
                 ),
             ]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
         parsed = json.loads(raw)
         return {

--- a/capabilities/scheduled_content_delivery/tools.py
+++ b/capabilities/scheduled_content_delivery/tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from langchain_core.tools import tool
 
 from core.config import settings
-from core.llm import ThinkingLevel, get_agent_llm
+from core.llm import ThinkingLevel, get_agent_llm, extract_llm_text
 from core.tool_guard import identity_bound
 
 
@@ -63,7 +63,7 @@ async def build_daily_briefing() -> str:
                 },
             ]
         )
-        content = str(getattr(ai_message, "content", "") or "").strip()
+        content = extract_llm_text(getattr(ai_message, "content", "")).strip()
         return content or fallback
     except Exception as exc:  # noqa: BLE001
         print(f"[BRIEFING] summary LLM failed, using fallback: {exc}")

--- a/capabilities/whiteboard/planner.py
+++ b/capabilities/whiteboard/planner.py
@@ -10,6 +10,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from core.config import settings
+from core.llm import extract_llm_text
 
 ALLOWED_ACTIONS = {"create_board", "augment_board", "none"}
 ALLOWED_CATEGORIES = {"trip", "event", "project", "meal", "general"}
@@ -170,7 +171,7 @@ async def comprehend_request(
         ai_message = await llm.ainvoke(
             [SystemMessage(content=COMPREHEND_SYSTEM_PROMPT), HumanMessage(content=user_content)]
         )
-        raw = str(getattr(ai_message, "content", "") or "").strip()
+        raw = extract_llm_text(getattr(ai_message, "content", "")).strip()
         raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
         start, end = raw.find("{"), raw.rfind("}")
         if start == -1 or end <= start:

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -881,7 +881,7 @@ async def agent_loop(state: AssistantState) -> Command[str]:
                     expected_tool_ids = ids
                     last_turn_kind = "ai_tc"
                     continue
-            history.append(AIMessage(content=str(message.content)))
+            history.append(AIMessage(content=extract_llm_text(message.content)))
             expected_tool_ids = set()
             last_turn_kind = "ai"
         elif isinstance(message, ToolMessage):

--- a/tests/test_gemini3_content_parts.py
+++ b/tests/test_gemini3_content_parts.py
@@ -1,0 +1,117 @@
+"""Gemini 3.x returns message content as a LIST OF TYPED PARTS, not a string.
+
+Live incident (2026-08-28 13:17-13:34): switching GEMINI_MODEL to
+gemini-3.7-flash broke every LLM-backed extraction in the app at once.
+Production logged, every ~20 seconds:
+
+    [EXPENSES] JSON parse failed: Expecting property name enclosed in
+    double quotes: line 1 column 3 (char 2)
+
+That error is the signature of json.loads() being handed the *repr of a
+list*: char 0 is '[', char 1 is '{', and char 2 is a single quote where a
+double quote was required. Eight call sites did
+
+    raw = str(getattr(ai_message, "content", "") or "").strip()
+
+which is correct for Gemini 2.5 (content is a str) and silently produces
+"[{'type': 'text', 'text': '...'}]" for Gemini 3.x. core/llm.py has carried
+extract_llm_text for exactly this since before the switch -- its docstring
+names the failure -- and none of these sites used it.
+
+The knock-on was worse than the parse failures: each failed extraction fell
+through to a second LLM call, the 10-minute email sweep began overlapping
+itself ("maximum number of running instances reached"), and the resulting
+call volume produced 504 DEADLINE_EXCEEDED -- at which point a bare "Hi"
+could not get a model response inside 45s and hit the timeout from #76.
+"""
+import json
+
+import pytest
+
+from core.llm import extract_llm_text
+
+
+# The exact shape Gemini 3.x hands back when thinking is enabled.
+GEMINI_3_CONTENT = [
+    {"type": "text", "text": '{"amount": 4.60, "currency": "SGD", "merchant": "BARCOOK BAKERY"}'}
+]
+GEMINI_25_CONTENT = '{"amount": 4.60, "currency": "SGD", "merchant": "BARCOOK BAKERY"}'
+
+
+def test_the_old_pattern_reproduces_the_exact_production_error():
+    """Pins the regression to its real signature, so a reader can match this
+    test to the log line that reported it."""
+    raw = str(GEMINI_3_CONTENT).strip()
+
+    with pytest.raises(json.JSONDecodeError) as excinfo:
+        json.loads(raw)
+
+    assert "Expecting property name enclosed in double quotes" in str(excinfo.value)
+    assert "line 1 column 3 (char 2)" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("content", [GEMINI_3_CONTENT, GEMINI_25_CONTENT])
+def test_extract_llm_text_yields_parseable_json_for_both_model_generations(content):
+    parsed = json.loads(extract_llm_text(content).strip())
+    assert parsed["amount"] == 4.60
+    assert parsed["merchant"] == "BARCOOK BAKERY"
+
+
+def test_extract_llm_text_drops_thinking_parts():
+    """Gemini 3.x interleaves reasoning parts with the answer; only the text
+    parts may reach a JSON parser."""
+    content = [
+        {"type": "thinking", "thinking": "The user wants the total. Let me look..."},
+        {"type": "text", "text": '{"amount": 12.5}'},
+    ]
+    assert json.loads(extract_llm_text(content).strip())["amount"] == 12.5
+
+
+def test_no_llm_response_is_stringified_with_bare_str():
+    """Guards every extraction site at once, including ones added later.
+
+    Eight files shared this bug -- expenses, reminders, recipes, routes,
+    memory, whiteboard, scheduled briefings and the dashboard -- because the
+    pattern was copied. A grep-style assertion is the cheapest thing that
+    catches the ninth copy.
+    """
+    import pathlib
+
+    offenders = []
+    for path in pathlib.Path(".").glob("**/*.py"):
+        if any(part in path.parts for part in (".venv", "__pycache__", "tests")):
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if 'str(getattr(ai_message, "content"' in line:
+                offenders.append(f"{path}:{lineno}")
+
+    assert not offenders, (
+        "these stringify an LLM response instead of using extract_llm_text, "
+        f"which breaks on Gemini 3.x list content: {offenders}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_expense_extraction_survives_gemini_3_content(monkeypatch):
+    """End-to-end on the path that actually failed in production."""
+    from langchain_core.messages import AIMessage
+
+    import capabilities.expenses.tools as et
+
+    class _Gemini3LLM:
+        async def ainvoke(self, messages):
+            return AIMessage(content=[{
+                "type": "text",
+                "text": '{"amount": 8.40, "currency": "SGD", "merchant": "COFFEE HIVE ADELPHI",'
+                        ' "category": "Dining", "date_iso": "", "confidence": 0.95,'
+                        ' "needs_clarification": false}',
+            }])
+
+    monkeypatch.setattr(et, "get_agent_llm", lambda *a, **k: _Gemini3LLM())
+
+    result = await et.extract_expense_from_text.ainvoke(
+        {"user_text": "coffee at hive adelphi 8.40"}
+    )
+
+    assert result["amount"] == 8.40
+    assert result["merchant"] == "COFFEE HIVE ADELPHI"


### PR DESCRIPTION
**Regression from #77 — my fault, caught in production within 20 minutes.** `GEMINI_MODEL` is already rolled back to `gemini-2.5-flash`; this is the fix that makes 3.7 safe to retry.

## What production showed

Every ~20 seconds from 13:20:

```
[EXPENSES] JSON parse failed: Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
```

That error is the signature of `json.loads()` being handed the **repr of a list** — char 0 is `[`, char 1 is `{`, char 2 is a single quote where a double quote was required. Reproduced byte-for-byte in a test.

Eight call sites did:

```python
raw = str(getattr(ai_message, "content", "") or "").strip()
```

Correct for Gemini 2.5, where `content` is a `str`. **Gemini 3.x returns content as a list of typed parts**, so this silently produced `"[{'type': 'text', 'text': '...'}]"` and every downstream `json.loads` failed.

`core/llm.py` has carried `extract_llm_text` for precisely this since before the switch — its docstring names the failure mode verbatim — and **not one of these sites used it**. Fixed across expenses, reminders, recipes, routes, memory, whiteboard planner, scheduled briefings, and `dashboard_api`; plus `agent_loop`, where a prior AI turn was entering history as a list repr.

## Why a parse bug looked like "the model hangs on hi"

Each failed extraction fell through to a *second* LLM call. The 10-minute email sweep began overlapping itself (`maximum number of running instances reached (1)`). The resulting call volume drew **504 DEADLINE_EXCEEDED**, at which point a bare "Hi" couldn't get a response inside 45s:

```
[AGENT_LOOP] round 0: awaiting model completion
[AGENT_LOOP] tool loop failed, using fallback: model call did not complete within 45s (abandoned)
```

Worth noting what *worked*: the turn did **not** hang. `bounded_call` fired at 45s and the user got the honest error reply instead of silence — exactly what #76 was for. The bug was upstream of it.

## Baseline confirmed, not assumed

Deployment `f2cfa50a` (06:27–13:10, on 2.5-flash) shows **zero** parse failures across 6h45m plus healthy traffic — `"What are my expenses"` → `get_user_expenses returned` → a real reply.

An earlier check that *appeared* to confirm this was invalid: it queried that window against the **current** deployment, which didn't exist yet, so its empty result meant nothing. Re-run against the prior deployment by id.

## Tests

`tests/test_gemini3_content_parts.py`, 6 new: the old pattern reproduces the exact production error string; `extract_llm_text` yields parseable JSON for both model generations; thinking parts are dropped; end-to-end expense extraction survives Gemini 3.x content; and a **repo-wide scan** asserts no file stringifies an LLM response with bare `str()` — which is what catches the ninth copy of a pattern that was already copied eight times.

Confirmed failing pre-fix, with the real log line in captured stdout.

**Full suite: 291 passed** (was 285). Same 7 pre-existing failures as #72–#78.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqspZRi6S43zMSafk4Qioc)_