### PR TITLE
fix(reliability): bound the graph turn + heal the wedged checkpoint layer

### DIFF
--- a/app/chat_api.py
+++ b/app/chat_api.py
@@ -15,9 +15,14 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import Command
 from sqlmodel import select, desc
 
+import asyncio
+
+from core.config import settings
 from core.db import async_session_factory
 from core.llm import extract_llm_text
 from core.models import UserProfile
+from core.tool_safety import bounded_call
+from core.background import fire_and_forget
 from orchestrator.graph import get_assistant_graph
 from app.ingress import telegram_ingress
 
@@ -134,7 +139,26 @@ async def handle_web_chat(request: ChatRequest) -> ChatResponse:
         }
 
         graph = get_assistant_graph()
-        result = await graph.ainvoke(initial_state, config=config)
+        try:
+            result = await bounded_call(
+                graph.ainvoke(initial_state, config=config),
+                settings.graph_turn_timeout_seconds,
+                "agent turn",
+            )
+        except asyncio.TimeoutError:
+            # Same wedged-checkpoint protection as the Telegram path: bound the
+            # turn, reset the checkpointer, tell the user honestly.
+            from orchestrator.checkpointer import reset_checkpointer
+
+            fire_and_forget(reset_checkpointer())
+            return ChatResponse(
+                status="error",
+                reply=(
+                    "⏳ that turn took me way too long — something snagged on my "
+                    "side and I've reset it. Please send that again."
+                ),
+                session_id=session_id,
+            )
 
         # Check for LangGraph Interrupts (e.g. HITL confirmation for spend/writes)
         interrupts = result.get("__interrupt__")

--- a/app/ingress.py
+++ b/app/ingress.py
@@ -15,6 +15,8 @@ from core.background import fire_and_forget
 from core.config import settings
 from core.db import async_session_factory
 from core.llm import extract_llm_text
+from core.tool_safety import bounded_call
+from orchestrator.checkpointer import reset_checkpointer
 from core.models import UserProfile
 from core.scheduler import list_active_jobs, run_now, update_user_timezone
 from orchestrator.graph import get_assistant_graph
@@ -1328,7 +1330,41 @@ class TelegramIngress:
                 return {"status": "ok", "processed": False, "reason": "chat_busy"}
             self._chat_lock_held_since[chat_id] = time.monotonic()
             try:
-                result = await get_assistant_graph().ainvoke(initial_state, config=config)
+                result = await bounded_call(
+                    get_assistant_graph().ainvoke(initial_state, config=config),
+                    settings.graph_turn_timeout_seconds,
+                    "agent turn",
+                )
+            except asyncio.TimeoutError:
+                # Live incident (chat=149917165, "Hi"): the checkpoint layer
+                # wedged and the turn hung forever -- no error, no reply, and
+                # the held lock starved every later message. The graph itself
+                # is unbounded by design; this outer bound exists so a wedged
+                # turn degrades into an honest error + a healed checkpointer
+                # instead of a dead chat.
+                from core.audit import report_production_bug
+
+                fire_and_forget(reset_checkpointer())
+                fire_and_forget(
+                    report_production_bug(
+                        user_id=user_id,
+                        thread_id=str(user_id or chat_id),
+                        error_context=(
+                            "Agent turn exceeded graph_turn_timeout_seconds; graph "
+                            "invocation abandoned (suspected wedged checkpoint I/O). "
+                            "Checkpointer reset triggered."
+                        ),
+                        detection_source="turn_timeout",
+                        severity="P1",
+                        fingerprint="agent_turn_checkpoint_hang",
+                    )
+                )
+                await send_telegram_message(
+                    chat_id,
+                    "⏳ that turn took me way too long — something snagged on my "
+                    "side and I've reset it. Please send that again.",
+                )
+                return {"status": "ok", "processed": False, "reason": "turn_timeout"}
             finally:
                 self._chat_lock_held_since.pop(chat_id, None)
                 lock.release()

--- a/core/config.py
+++ b/core/config.py
@@ -84,6 +84,11 @@ class Settings(BaseSettings):
 
     # Capability Access Control — skills a non-admin user must never reach.
     admin_only_capabilities: set[str] = {"code-exec"}
+    # Outer bound on a whole graph turn (ingress + web chat). The agent loop
+    # inside is deliberately unbounded; this exists only so a wedged turn --
+    # e.g. hung checkpoint I/O -- degrades into an honest error reply and a
+    # checkpointer reset instead of a silently dead chat.
+    graph_turn_timeout_seconds: float = 600.0
 
     def is_admin(self, user_id: Optional[object]) -> bool:
         """

--- a/orchestrator/checkpointer.py
+++ b/orchestrator/checkpointer.py
@@ -31,7 +31,15 @@ async def setup_checkpointer():
         conn_string = settings.database_url.replace(
             "postgresql+asyncpg://", "postgresql://"
         )
-        iterator = AsyncPostgresSaver.from_conn_string(conn_string, pipeline=True)
+        # DB-level hang bound (live incident, chat=149917165): a dead/stale
+        # pooled connection made checkpoint I/O hang forever and silently --
+        # the turn held the per-chat lock, every later message starved, and
+        # nothing printed. statement_timeout makes the SERVER kill a wedged
+        # statement after 30s so the pool surfaces an error instead. Delivered
+        # via the libpq `options` parameter because from_conn_string in the
+        # installed langgraph version accepts only a conninfo string.
+        bounded_conn_string = _with_statement_timeout(conn_string, CHECKPOINT_STATEMENT_TIMEOUT_MS)
+        iterator = AsyncPostgresSaver.from_conn_string(bounded_conn_string, pipeline=True)
         saver = await iterator.__aenter__()
         await _run_postgres_migrations(conn_string)
         _postgres_iterator = iterator
@@ -40,6 +48,40 @@ async def setup_checkpointer():
     except Exception as exc:  # noqa: BLE001
         print(f"[CHECKPOINTER] PostgresSaver unavailable, using MemorySaver: {exc}")
         _checkpointer = MemorySaver()
+
+
+CHECKPOINT_STATEMENT_TIMEOUT_MS = 30_000
+
+
+def _with_statement_timeout(conn_string: str, timeout_ms: int) -> str:
+    separator = "&" if "?" in conn_string else "?"
+    return f"{conn_string}{separator}options=-c%20statement_timeout%3D{timeout_ms}"
+
+
+async def reset_checkpointer() -> None:
+    """Rebuild the Postgres checkpointer from scratch.
+
+    Incident-driven: a wedged checkpoint connection hung every turn silently.
+    statement_timeout now bounds each statement, but a pool that already
+    handed out dead connections can keep doing so; rebuilding the saver gives
+    the next turn a fresh pool. Turns running during the rebuild fall back to
+    the in-memory checkpointer instead of hanging. Best-effort and bounded:
+    tearing down the old pool must never hang the heal itself.
+    """
+    global _checkpointer, _postgres_iterator
+    from core.tool_safety import bounded_call
+
+    old_iterator = _postgres_iterator
+    _checkpointer = MemorySaver()
+    _postgres_iterator = None
+    if old_iterator is not None:
+        try:
+            await bounded_call(
+                old_iterator.__aexit__(None, None, None), 10.0, "checkpointer teardown"
+            )
+        except Exception as exc:  # noqa: BLE001 - the old pool is the patient
+            print(f"[CHECKPOINTER] old pool teardown abandoned: {exc}")
+    await setup_checkpointer()
 
 
 async def _run_postgres_migrations(conn_string: str) -> None:

--- a/tests/test_checkpointer_guard.py
+++ b/tests/test_checkpointer_guard.py
@@ -1,0 +1,67 @@
+"""The checkpoint-wedge guard: statement_timeout on checkpointer connections,
+a bounded graph turn, and a checkpointer heal."""
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.main import app
+from orchestrator.checkpointer import (
+    CHECKPOINT_STATEMENT_TIMEOUT_MS,
+    _with_statement_timeout,
+    get_checkpointer,
+    reset_checkpointer,
+)
+
+client = TestClient(app)
+
+
+def test_statement_timeout_is_appended_to_conn_string():
+    bounded = _with_statement_timeout("postgresql://u:p@h:5432/db", CHECKPOINT_STATEMENT_TIMEOUT_MS)
+    assert f"options=-c%20statement_timeout%3D{CHECKPOINT_STATEMENT_TIMEOUT_MS}" in bounded
+
+    # a conn_string that already has query params must get '&' not '?'
+    bounded2 = _with_statement_timeout("postgresql://u:p@h:5432/db?sslmode=require", 30_000)
+    assert "sslmode=require&options=-c" in bounded2
+
+
+def test_reset_checkpointer_falls_back_and_recovers():
+    """reset_checkpointer must always leave a working checkpointer behind --
+    MemorySaver when Postgres is not configured (local/dev), PostgresSaver
+    after a successful re-setup in production."""
+    asyncio.run(reset_checkpointer())
+    assert get_checkpointer() is not None
+
+
+def test_hung_graph_turn_returns_honest_fallback(monkeypatch):
+    """Live incident (chat=149917165, 'Hi'): a wedged checkpoint layer hung
+    the turn forever -- no error, no reply, and the held lock starved every
+    later message. The graph invocation is now bounded; a hung turn produces
+    an honest reply instead of silence."""
+    import app.chat_api as chat_api
+    from core.config import settings
+
+    class _HangingGraph:
+        async def ainvoke(self, state, config=None):
+            await asyncio.sleep(30)
+
+    monkeypatch.setattr(chat_api, "get_assistant_graph", lambda: _HangingGraph())
+    monkeypatch.setattr(settings, "graph_turn_timeout_seconds", 0.2)
+
+    resp = client.post(
+        "/api/chat",
+        json={"message": "hi", "session_id": "diag-hang-test", "user_id": 999999},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "took me way too long" in body["reply"]
+
+
+def test_graph_turn_timeout_is_generous_not_zero():
+    """The bound is an incident backstop, not a reasoning limit: default 600s
+    so legitimate multi-tool turns (email sweeps, transit chains) survive."""
+    from core.config import settings
+
+    assert settings.graph_turn_timeout_seconds >= 300.0


### PR DESCRIPTION
## Live incident ("Hi" hangs forever)

Railway production: *"Hi"* → `[AGENT_LOOP] round 0: awaiting model completion` → **~29 hours of silence** (175 sweeps). No error print, no fallback reply, no `[TG OUT]`. Reproduced on demand via `/api/chat` (150s+ no response; two diagnostic turns never reached the node at all). Later messages starved on the held per-chat lock — the whole bot looked dead.

## Root cause

**Checkpoint I/O.** `AsyncPostgresSaver` runs its own psycopg pool — separate from the healthy SQLModel engine that the ops sweep and dashboard use — and nothing bounded it. A dead/stale pooled connection hangs checkpoint load/save forever, silently. The first wedge hung a turn's post-node save (that turn printed `round 0`, model answered, save wedged); every later turn then hung at checkpoint **load** (which is why my diagnostics never even printed `round 0`). The 45s `bounded_call` on the model call never fired because the turn was stuck in checkpoint I/O — inside the graph runtime, outside its reach.

## Fix

1. **`statement_timeout` (30s)** on the checkpointer's connections via the libpq `options` conninfo parameter — the **server** now kills a wedged statement, so the pool surfaces an error instead of hanging. (Installed `from_conn_string` accepts only a conninfo string, hence the URL param.)
2. **Graph invocation bounded** at both call sites (Telegram ingress + `/api/chat`) via `bounded_call` + `settings.graph_turn_timeout_seconds` (default **600s** — an incident backstop, not a reasoning limit; legitimate multi-tool turns still fit). On timeout: honest error reply, P1 production-bug report, and **`reset_checkpointer()`** — bounded teardown + fresh pool so later turns don't cascade on dead connections. Turns running during the heal fall back to the in-memory checkpointer.
3. `wedged_chats()` detection already existed in the ops sweep (recorded as issue #2 in the logs); **recovery** was the missing half.

## Also

Railway's `GEMINI_MODEL` env pin was still `gemini-2.5-flash` (overriding PR #77's new default) — updated to `gemini-3.7-flash`, so this deploy completes the intended model switch. (Not the hang's cause — the wedge hit 2.5-flash.)

## Tests

4 new (statement_timeout conninfo, reset falls back + recovers, hung graph turn returns the honest fallback, default bound is generous). **302 passed** — one pre-existing env-dependent failure (`test_llm_model_config` reads the local `.env` pin; documented).