### PR TITLE
feat(llm): capacity circuit breaker — degrade to a fallback model

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
     # e.g. hung checkpoint I/O -- degrades into an honest error reply and a
     # checkpointer reset instead of a silently dead chat.
     graph_turn_timeout_seconds: float = 600.0
+    # Degraded-mode model: when the primary Gemini model fails at Google's
+    # edge (503 high-demand / 504 deadline), the agent loop finishes the turn
+    # on this model instead of shipping an error. Empty string disables.
+    llm_fallback_model: str = "gemini-2.5-flash"
 
     def is_admin(self, user_id: Optional[object]) -> bool:
         """

--- a/core/llm.py
+++ b/core/llm.py
@@ -102,6 +102,7 @@ def get_llm(
     role: str = "agent_core",
     complexity: Union[ThinkingLevel, str] = ThinkingLevel.MEDIUM,
     temperature: float = 0.0,
+    model: Optional[str] = None,
 ) -> Any:
     """
     Factory function for Hybrid Multimodal (Gemini Flash) & Variable-Thinking (DeepSeek v4 Flash) LLM routing.
@@ -116,9 +117,10 @@ def get_llm(
     """
     if role == "multimodal_io":
         api_key = settings.active_gemini_api_key or "test_google_key"
-        logger.debug(f"Initializing Google Gemini ({settings.gemini_model}) for multimodal_io role.")
+        chosen_model = model or settings.gemini_model
+        logger.debug(f"Initializing Google Gemini ({chosen_model}) for multimodal_io role.")
         return ChatGoogleGenerativeAI(
-            model=settings.gemini_model,
+            model=chosen_model,
             google_api_key=api_key,
             timeout=LLM_REQUEST_TIMEOUT_SECONDS,
             max_retries=LLM_MAX_RETRIES,
@@ -128,9 +130,10 @@ def get_llm(
     elif role == "agent_core":
         if settings.llm_provider == "gemini" or (not settings.deepseek_api_key and settings.active_gemini_api_key):
             api_key = settings.active_gemini_api_key or "test_google_key"
-            logger.debug(f"Initializing Google Gemini ({settings.gemini_model}) for agent_core role.")
+            chosen_model = model or settings.gemini_model
+            logger.debug(f"Initializing Google Gemini ({chosen_model}) for agent_core role.")
             return ChatGoogleGenerativeAI(
-                model=settings.gemini_model,
+                model=chosen_model,
                 google_api_key=api_key,
                 timeout=LLM_REQUEST_TIMEOUT_SECONDS,
                 max_retries=LLM_MAX_RETRIES,
@@ -187,9 +190,11 @@ def get_judge_llm(temperature: float = 0.0) -> ChatGoogleGenerativeAI:
 def get_agent_llm(
     complexity: Union[ThinkingLevel, str] = ThinkingLevel.MEDIUM,
     temperature: float = 0.0,
+    model: Optional[str] = None,
 ) -> ChatOpenAI:
-    """Convenience helper to obtain DeepSeek v4 Flash with the specified thinking complexity level."""
-    return get_llm(role="agent_core", complexity=complexity, temperature=temperature)
+    """Convenience helper to obtain the agent-core LLM. `model` overrides the
+    provider's default -- used by the degraded-mode fallback path."""
+    return get_llm(role="agent_core", complexity=complexity, temperature=temperature, model=model)
 
 
 def extract_llm_text(content: Any) -> str:

--- a/orchestrator/agent_loop.py
+++ b/orchestrator/agent_loop.py
@@ -639,6 +639,31 @@ async def _run_tool_loop(
     llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7)
     llm_with_tools = llm.bind_tools(tools)
     link_tool_used = False
+    degraded_to = ""  # set once this turn degrades to the fallback model
+
+    async def _invoke_model_bounded():
+        """One model call, with the capacity circuit breaker: when the primary
+        Gemini model is failing at Google's edge (503 high-demand / 504
+        deadline / 429), finish the turn on llm_fallback_model instead of
+        shipping an error. Degrades at most once per turn; a fallback failure
+        propagates to the honest-error path unchanged."""
+        nonlocal llm, llm_with_tools, degraded_to
+        try:
+            return await _invoke_model(llm_with_tools, hist)
+        except Exception as exc:  # noqa: BLE001 - classified below
+            if degraded_to or not settings.llm_fallback_model or settings.llm_provider != "gemini":
+                raise
+            err = f"{type(exc).__name__}: {exc}"
+            if not any(
+                marker in err
+                for marker in ("503", "504", "429", "UNAVAILABLE", "DEADLINE_EXCEEDED", "overloaded", "high demand")
+            ):
+                raise
+            degraded_to = settings.llm_fallback_model
+            print(f"[AGENT_LOOP] primary model unavailable ({err[:200]}); degrading to {degraded_to}")
+            llm = get_agent_llm(complexity=ThinkingLevel.MEDIUM, temperature=0.7, model=degraded_to)
+            llm_with_tools = llm.bind_tools(tools)
+            return await _invoke_model(llm_with_tools, hist)
 
     # Round-progress tracing: with no per-turn wall-clock ceiling (by design,
     # see MAX_TOOL_ROUNDS above), any single await here -- the model call or
@@ -648,7 +673,7 @@ async def _run_tool_loop(
     # if a turn does go silent, Railway logs show exactly which round and
     # which call it was last seen entering instead of nothing at all.
     print("[AGENT_LOOP] round 0: awaiting model completion")
-    ai_message = await _invoke_model(llm_with_tools, hist)
+    ai_message = await _invoke_model_bounded()
     for _round in range(MAX_TOOL_ROUNDS):
         tool_calls = getattr(ai_message, "tool_calls", None) or []
         if not tool_calls:
@@ -660,7 +685,7 @@ async def _run_tool_loop(
         ):
             link_tool_used = True
         print(f"[AGENT_LOOP] round {_round + 1}: awaiting model completion")
-        ai_message = await _invoke_model(llm_with_tools, hist)
+        ai_message = await _invoke_model_bounded()
 
     text = extract_llm_text(getattr(ai_message, "content", "")).strip()
     round_budget_exhausted = False

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -1,0 +1,95 @@
+"""The model-fallback circuit breaker: primary Gemini capacity failures
+(503 high-demand / 504 deadline) degrade the turn to llm_fallback_model
+instead of shipping an error."""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+import orchestrator.agent_loop as al
+from core.config import settings
+from orchestrator.agent_loop import agent_loop
+
+
+class _FakeLLM:
+    def __init__(self, kind: str):
+        self.kind = kind
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        if self.kind == "primary":
+            raise Exception(
+                "504 DEADLINE_EXCEEDED. {'error': {'code': 504, 'message': "
+                "'Deadline expired before operation could complete.', 'status': 'DEADLINE_EXCEEDED'}}"
+            )
+        return AIMessage(content="hi there! (degraded-model reply)")
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_degrades_to_fallback_model(monkeypatch):
+    made = []
+
+    def fake_get_llm(*args, **kwargs):
+        kind = "fallback" if kwargs.get("model") else "primary"
+        made.append(kind)
+        return _FakeLLM(kind)
+
+    monkeypatch.setattr(al, "get_agent_llm", fake_get_llm)
+    monkeypatch.setattr(settings, "llm_provider", "gemini")
+    monkeypatch.setattr(settings, "llm_fallback_model", "gemini-2.5-flash")
+
+    result = await agent_loop({
+        "user_id": 4242,
+        "current_timezone": "Asia/Singapore",
+        "messages": [HumanMessage(content="hi")],
+    })
+
+    assert made == ["primary", "fallback"], made
+    reply = str(result.update["messages"][-1].content)
+    assert "degraded-model reply" in reply
+
+
+@pytest.mark.asyncio
+async def test_non_capacity_error_does_not_degrade(monkeypatch):
+    """A non-capacity failure (bad request shape, auth, bug) must NOT silently
+    switch models -- it propagates to the honest-error path."""
+    made = []
+
+    class _BrokenLLM:
+        def bind_tools(self, tools):
+            return self
+
+        async def ainvoke(self, messages):
+            raise ValueError("malformed request")
+
+    def fake_get_llm(*args, **kwargs):
+        made.append(kwargs.get("model") or "primary")
+        return _BrokenLLM()
+
+    monkeypatch.setattr(al, "get_agent_llm", fake_get_llm)
+    monkeypatch.setattr(settings, "llm_provider", "gemini")
+    monkeypatch.setattr(settings, "llm_fallback_model", "gemini-2.5-flash")
+
+    result = await agent_loop({
+        "user_id": 4242,
+        "current_timezone": "Asia/Singapore",
+        "messages": [HumanMessage(content="hi")],
+    })
+
+    assert made == ["primary"], made
+    reply = str(result.update["messages"][-1].content)
+    assert "glitched" in reply  # _ERROR_REPLY_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_fallback_disabled_ships_error(monkeypatch):
+    monkeypatch.setattr(al, "get_agent_llm", lambda *a, **k: _FakeLLM("primary"))
+    monkeypatch.setattr(settings, "llm_provider", "gemini")
+    monkeypatch.setattr(settings, "llm_fallback_model", "")
+
+    result = await agent_loop({
+        "user_id": 4242,
+        "current_timezone": "Asia/Singapore",
+        "messages": [HumanMessage(content="hi")],
+    })
+    assert "glitched" in str(result.update["messages"][-1].content)


### PR DESCRIPTION
## Live verification after PR #80

The checkpoint-wedge guard works — turns now complete honestly instead of hanging forever (41s vs 29h). But the model call itself fails: **gemini-3.7-flash is returning `504 DEADLINE_EXCEEDED`** at Google's edge (same family as the earlier `503 high demand`). A capacity outage on the primary model must not make the bot useless.

## Fix: capacity circuit breaker

- `_invoke_model_bounded` in the tool loop: on a **capacity-class** failure (`503` / `504` / `429` / `UNAVAILABLE` / `DEADLINE_EXCEEDED` / overload), the turn degrades **once** to `settings.llm_fallback_model` (default `gemini-2.5-flash`) and keeps going — subsequent rounds ride the fallback.
- **Non-capacity failures** (malformed request, auth, bugs) and fallback-model failures propagate to the honest-error path unchanged — no silent model swapping for real bugs.
- Disabled when `llm_fallback_model` is empty. `get_llm`/`get_agent_llm` gained a `model` override to serve the degraded path.
- Local `.env` model pin updated 2.5 → 3.7 to match production (fixes the env-dependent `test_llm_model_config` failure locally; Railway's pin was already switched in the previous deploy).

## Tests

3 new. Full suite: **305 passed**.